### PR TITLE
Fix RPC v2 negotiation for large model catalogs

### DIFF
--- a/lib/omp/rpc-utility.test.mjs
+++ b/lib/omp/rpc-utility.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("utility RPC processes negotiate v2 before sending commands", async () => {
+  const source = await readFile(new URL("./rpc-utility.ts", import.meta.url), "utf8");
+  const negotiations = source.match(/await proc\.negotiateProtocol\(ready\)/g) ?? [];
+
+  assert.equal(negotiations.length, 2);
+});

--- a/lib/omp/rpc-utility.ts
+++ b/lib/omp/rpc-utility.ts
@@ -116,7 +116,8 @@ async function startProcess(state: UtilityRpcState): Promise<RpcProcess> {
     },
   });
   try {
-    await proc.waitReady(READY_TIMEOUT_MS);
+    const ready = await proc.waitReady(READY_TIMEOUT_MS);
+    await proc.negotiateProtocol(ready);
   } catch (error) {
     void proc.dispose();
     throw error;
@@ -165,7 +166,8 @@ export async function runIsolatedUtilityCommand<T = unknown>(
     env: options.env,
   });
   try {
-    await proc.waitReady(READY_TIMEOUT_MS);
+    const ready = await proc.waitReady(READY_TIMEOUT_MS);
+    await proc.negotiateProtocol(ready);
     return await proc.sendCommand<T>(command, options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS);
   } finally {
     // Await the child's exit (not fire-and-forget): callers like the


### PR DESCRIPTION
Fixes #1.\n\nThe utility RPC process now negotiates protocol v2 after the ready frame and before requesting the model catalog. This enables chunk reassembly for responses larger than the protocol v1 1 MiB limit. The isolated model-provider test process follows the same startup sequence.\n\nIncludes focused regression coverage for both utility startup paths.\n\nVerification:\n- npm test (337 passed, 4 skipped)\n- node_modules/.bin/tsc --noEmit\n- ESLint on the changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Negotiate RPC protocol v2 immediately after the ready frame in utility processes and the isolated test process. Previously we stayed on v1, so model catalog responses over 1 MiB could fail; with v2, chunk reassembly supports large catalogs.

- Inserts `proc.negotiateProtocol(ready)` right after `waitReady(...)` in both `startProcess` and `runIsolatedUtilityCommand`, before any commands; no caller-facing API changes.
- Adds a focused test that verifies both startup paths negotiate v2 before sending commands; existing tests, typecheck, and lint pass.

<sup>Written for commit 5aa8e575aadaa0de5926c55df1041be8e53d0989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utility RPC startup reliability by completing protocol negotiation before sending commands.
  * Preserved existing timeout and disposal error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->