### PR TITLE
fix(auth): negotiate RPC v2 before interactive login

### DIFF
--- a/app/api/auth/login/[provider]/route.ts
+++ b/app/api/auth/login/[provider]/route.ts
@@ -165,7 +165,8 @@ export async function GET(
       req.signal.addEventListener("abort", cleanup);
 
       try {
-        await child.waitReady(READY_TIMEOUT_MS);
+        const ready = await child.waitReady(READY_TIMEOUT_MS);
+        await child.negotiateProtocol(ready);
         await child.sendCommand({ type: "login", providerId: provider }, LOGIN_TIMEOUT_MS);
         enableProvider(provider);
         invalidateModelsCache();

--- a/lib/api-contract.test.mjs
+++ b/lib/api-contract.test.mjs
@@ -12,6 +12,17 @@ test("agent command routes reject malformed commands and map RPC failures to 400
   assert.match(newRoute, /newSessionErrorResponse/);
 });
 
+test("interactive login negotiates RPC v2 before sending the login command", async () => {
+  const route = await readFile(new URL("../app/api/auth/login/[provider]/route.ts", import.meta.url), "utf8");
+  const waitReady = route.indexOf("await child.waitReady(READY_TIMEOUT_MS)");
+  const negotiate = route.indexOf("await child.negotiateProtocol(ready)");
+  const login = route.indexOf('await child.sendCommand({ type: "login"');
+
+  assert.ok(waitReady >= 0);
+  assert.ok(negotiate > waitReady);
+  assert.ok(login > negotiate);
+});
+
 test("session archive route stops live children and maps missing sessions", async () => {
   const route = await readFile(new URL("../app/api/sessions/[id]/archive/route.ts", import.meta.url), "utf8");
   const utils = await readFile(new URL("../lib/api-utils.ts", import.meta.url), "utf8");


### PR DESCRIPTION
Follow-up to #3. The utility RPC fix covered \
* get_available_models\nbut the dedicated interactive login flow still called waitReady() -> login without negotiating RPC v2 first. This aligns login with every other production RpcProcess startup path:\n\n\n waitReady()\n negotiateProtocol()\n login\n\n\nFixes the latent 1 MiB transport-limit edge case for unusually large OAuth/UI frames and adds a regression test (lib/api-contract.test.mjs) that asserts waitReady -> negotiateProtocol -> login ordering.\n\nVerified: npm test (337 passed, 4 skipped), tsc --noEmit, eslint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interactive login now negotiates RPC v2 before sending the login command, aligning it with other `RpcProcess` startup paths. Previously it called waitReady() then login, which could hit the 1 MiB transport limit on large OAuth/UI frames; now it does waitReady → negotiateProtocol → login.

- app/api/auth/login/[provider]/route.ts: capture the result of waitReady and call negotiateProtocol before sending the login command.
- lib/api-contract.test.mjs: add a regression test that asserts the waitReady → negotiateProtocol → login ordering.
- No config or migration changes; behavior of other startup paths is unchanged.

<sup>Written for commit ae6968dbcbc3bc9b6029631488f11948a0332487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

