### PR TITLE
Stream updates for sessions started outside the web UI

### DIFF
--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -1,4 +1,5 @@
 import { getRunningRpcSessionIds, subscribeRunningSessions } from "@/lib/rpc-manager";
+import { subscribeSessionFileChanges } from "@/lib/session-watcher";
 
 export const dynamic = "force-dynamic";
 
@@ -30,6 +31,16 @@ export async function GET(req: Request) {
         }
       });
 
+      // Sessions omp writes outside the web UI produce no RPC events, so the
+      // only signal that they advanced is the file itself.
+      const unsubscribeFiles = subscribeSessionFileChanges((sessionIds) => {
+        try {
+          encode({ type: "sessions-changed", sessionIds, refreshSessionList: true });
+        } catch {
+          // controller already closed
+        }
+      });
+
       // Initial snapshot so the client renders the correct state immediately.
       // (A duplicate frame here is harmless: the client just sets the same set.)
       encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
@@ -46,6 +57,7 @@ export async function GET(req: Request) {
       const cleanup = () => {
         clearInterval(heartbeat);
         unsubscribe();
+        unsubscribeFiles();
         try { controller.close(); } catch { /* already closed */ }
       };
       streamCleanup = cleanup;

--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -33,11 +33,12 @@ export async function GET(req: Request) {
 
       // Sessions omp writes outside the web UI produce no RPC events, so the
       // only signal that they advanced is the file itself.
-      const unsubscribeFiles = subscribeSessionFileChanges((sessionIds) => {
+      let unsubscribeFiles: (() => void) | null = null;
+      unsubscribeFiles = subscribeSessionFileChanges((sessionIds) => {
         try {
           encode({ type: "sessions-changed", sessionIds, refreshSessionList: true });
         } catch {
-          // controller already closed
+          try { unsubscribeFiles?.(); } catch { /* already cleaned up */ }
         }
       });
 

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -14,6 +14,7 @@ import { clearLastOpenSession, setLastOpenSession, workspaceKeyOf } from "@/lib/
 import { groupSessionsByProject, projectActivityCounts, sortManagedProjects } from "@/lib/project-ordering";
 import { comparableProjectPath } from "@/lib/comparable-path";
 import { Check, ChevronDown, ChevronRight, FileUp, Folder, GitBranch, MoreHorizontal, Plus, RefreshCw, Search, Settings2, SlidersHorizontal, Trash2, Upload } from "lucide-react";
+import { publishSessionsChanged } from "@/lib/session-change-bus";
 
 declare global {
   interface Window {
@@ -702,11 +703,15 @@ export function SessionSidebar({ selectedSessionId, optimisticSession, onSelectS
           type?: string;
           runningSessionIds?: string[];
           refreshSessionList?: boolean;
+          sessionIds?: string[];
         };
         if (data.type === "running") {
           sseAuthoritativeRef.current = true;
           setRunningSessionIds(new Set(data.runningSessionIds ?? []));
           if (data.refreshSessionList) scheduleRefresh();
+        } else if (data.type === "sessions-changed") {
+          if (data.refreshSessionList) scheduleRefresh();
+          publishSessionsChanged(data.sessionIds ?? []);
         }
       } catch {
         // ignore malformed frames

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -23,6 +23,7 @@ import { expandWebSlashCommand } from "@/lib/web-slash-commands";
 import { createActiveGoal, parseActiveGoal, type ActiveGoal, type ActivePlan } from "@/lib/web-mode-state";
 import type { HostToolDefinition, HostUriSchemeDefinition, RpcAvailableSlashCommand, SessionStatsInfo, TodoPhase } from "@/lib/pi-types";
 import { isRecord } from "@/lib/type-guards";
+import { subscribeSessionsChanged } from "@/lib/session-change-bus";
 import {
   parseSubagentActivityEvent,
   parseSubagentLifecycle,
@@ -1152,6 +1153,18 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setSlashCommandsLoading(false);
     }
   }, [ensureNewSession]);
+
+  // A session omp is writing outside the web UI has no RPC stream to deliver
+  // its turns, so reload the transcript when the watcher reports that this
+  // session's file grew. Skipped while an event stream is attached: that
+  // stream is already the authority and a reload would fight it.
+  useEffect(() => {
+    return subscribeSessionsChanged((sessionIds) => {
+      const sid = sessionIdRef.current;
+      if (!sid || eventSourceRef.current || !sessionIds.includes(sid)) return;
+      void loadSession(sid);
+    });
+  }, [loadSession]);
 
   // Reconnect actions captured after their definitions (host-tool and URI
   // registrations are per-wrapper and are not persisted by omp, and the

--- a/lib/session-change-bus.test.mjs
+++ b/lib/session-change-bus.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./session-change-bus.ts");
+}
+
+test("delivers changed session ids to every subscriber", async () => {
+  const { publishSessionsChanged, subscribeSessionsChanged } = await loadSubject();
+  const first = [];
+  const second = [];
+  const unsubscribeFirst = subscribeSessionsChanged((ids) => first.push(ids));
+  const unsubscribeSecond = subscribeSessionsChanged((ids) => second.push(ids));
+
+  publishSessionsChanged(["a", "b"]);
+
+  assert.deepEqual(first, [["a", "b"]]);
+  assert.deepEqual(second, [["a", "b"]]);
+  unsubscribeFirst();
+  unsubscribeSecond();
+});
+
+test("stops delivering after unsubscribe and ignores empty batches", async () => {
+  const { publishSessionsChanged, subscribeSessionsChanged } = await loadSubject();
+  const seen = [];
+  const unsubscribe = subscribeSessionsChanged((ids) => seen.push(ids));
+
+  publishSessionsChanged([]);
+  assert.deepEqual(seen, []);
+
+  unsubscribe();
+  publishSessionsChanged(["a"]);
+  assert.deepEqual(seen, []);
+});
+
+test("a throwing subscriber does not stop the others", async () => {
+  const { publishSessionsChanged, subscribeSessionsChanged } = await loadSubject();
+  const seen = [];
+  const unsubscribeBad = subscribeSessionsChanged(() => {
+    throw new Error("subscriber blew up");
+  });
+  const unsubscribeGood = subscribeSessionsChanged((ids) => seen.push(ids));
+
+  publishSessionsChanged(["a"]);
+
+  assert.deepEqual(seen, [["a"]]);
+  unsubscribeBad();
+  unsubscribeGood();
+});

--- a/lib/session-change-bus.ts
+++ b/lib/session-change-bus.ts
@@ -1,0 +1,26 @@
+// The running-events stream is consumed by the sidebar, but the open
+// transcript lives in useAgentSession under a sibling component. This carries
+// "these session files changed on disk" from one to the other without
+// threading a callback through the tree.
+
+type Listener = (sessionIds: string[]) => void;
+
+const listeners = new Set<Listener>();
+
+export function publishSessionsChanged(sessionIds: string[]): void {
+  if (sessionIds.length === 0) return;
+  for (const listener of [...listeners]) {
+    try {
+      listener(sessionIds);
+    } catch {
+      // a failing subscriber must not stop the others
+    }
+  }
+}
+
+export function subscribeSessionsChanged(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/lib/session-watcher.ts
+++ b/lib/session-watcher.ts
@@ -1,0 +1,87 @@
+import { watch, type FSWatcher } from "fs";
+import { join } from "path";
+import {
+  getAgentDir,
+  invalidateSessionListCache,
+  resolveSessionIdByPath,
+} from "./session-reader";
+
+// omp owns the writes to a session's JSONL. ompweb streams RPC events only for
+// the sessions it spawned itself, so a session started outside the web UI — by
+// `omp` in a terminal, or by a harness that launches omp — never updated while
+// it was open: the file grew and nothing told the browser. This watches the
+// session tree and reports which session ids changed, which the running-events
+// stream forwards to the client.
+
+type Listener = (sessionIds: string[]) => void;
+
+const DEBOUNCE_MS = 250;
+
+const listeners = new Set<Listener>();
+let watcher: FSWatcher | null = null;
+let pendingPaths = new Set<string>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flush(): void {
+  flushTimer = null;
+  const paths = [...pendingPaths];
+  pendingPaths = new Set();
+  if (paths.length === 0) return;
+
+  // A changed file means the cached list's mtimes and message counts are stale.
+  invalidateSessionListCache();
+
+  void Promise.all(paths.map((path) => resolveSessionIdByPath(path).catch(() => undefined)))
+    .then((ids) => {
+      const sessionIds = [...new Set(ids.filter((id): id is string => Boolean(id)))];
+      if (sessionIds.length === 0) return;
+      for (const listener of listeners) {
+        try {
+          listener(sessionIds);
+        } catch {
+          // a failing subscriber must not stop the others
+        }
+      }
+    })
+    .catch(() => {
+      // resolution failures are not worth tearing the watcher down for
+    });
+}
+
+function ensureWatcher(): void {
+  if (watcher) return;
+  const sessionsDir = join(getAgentDir(), "sessions");
+  try {
+    watcher = watch(sessionsDir, { recursive: true, persistent: false }, (_event, filename) => {
+      if (!filename) return;
+      const name = filename.toString();
+      if (!name.endsWith(".jsonl")) return;
+      pendingPaths.add(join(sessionsDir, name));
+      if (!flushTimer) flushTimer = setTimeout(flush, DEBOUNCE_MS);
+    });
+    watcher.on("error", () => {
+      watcher?.close();
+      watcher = null;
+    });
+  } catch {
+    // No sessions directory yet, or the platform refused a recursive watch.
+    // Live updates degrade to the previous behaviour; nothing else breaks.
+    watcher = null;
+  }
+}
+
+export function subscribeSessionFileChanges(listener: Listener): () => void {
+  ensureWatcher();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size > 0) return;
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    pendingPaths = new Set();
+    watcher?.close();
+    watcher = null;
+  };
+}

--- a/lib/session-watcher.ts
+++ b/lib/session-watcher.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import {
   getAgentDir,
   invalidateSessionListCache,
+  listAllSessions,
   resolveSessionIdByPath,
 } from "./session-reader";
 
@@ -20,16 +21,42 @@ const DEBOUNCE_MS = 250;
 const listeners = new Set<Listener>();
 let watcher: FSWatcher | null = null;
 let pendingPaths = new Set<string>();
+let pendingUnknown = false;
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+const RETRY_MS = 5000;
 
 function flush(): void {
   flushTimer = null;
   const paths = [...pendingPaths];
   pendingPaths = new Set();
-  if (paths.length === 0) return;
+  const hadUnknown = pendingUnknown;
+  pendingUnknown = false;
+  if (paths.length === 0 && !hadUnknown) return;
 
   // A changed file means the cached list's mtimes and message counts are stale.
   invalidateSessionListCache();
+
+  if (hadUnknown) {
+    // filename was null — fs.watch coalesced the event or overflowed. We
+    // don't know which file changed, so rescan the whole tree.
+    void listAllSessions()
+      .then((sessions) => {
+        const sessionIds = sessions.map((s) => s.id);
+        if (sessionIds.length === 0) return;
+        for (const listener of listeners) {
+          try {
+            listener(sessionIds);
+          } catch {
+            // a failing subscriber must not stop the others
+          }
+        }
+      })
+      .catch(() => {
+        // resolution failures are not worth tearing the watcher down for
+      });
+    return;
+  }
 
   void Promise.all(paths.map((path) => resolveSessionIdByPath(path).catch(() => undefined)))
     .then((ids) => {
@@ -48,12 +75,24 @@ function flush(): void {
     });
 }
 
+function scheduleRetry(): void {
+  if (retryTimer || listeners.size === 0) return;
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    ensureWatcher();
+  }, RETRY_MS);
+}
+
 function ensureWatcher(): void {
-  if (watcher) return;
+  if (watcher || retryTimer) return;
   const sessionsDir = join(getAgentDir(), "sessions");
   try {
     watcher = watch(sessionsDir, { recursive: true, persistent: false }, (_event, filename) => {
-      if (!filename) return;
+      if (!filename) {
+        pendingUnknown = true;
+        if (!flushTimer) flushTimer = setTimeout(flush, DEBOUNCE_MS);
+        return;
+      }
       const name = filename.toString();
       if (!name.endsWith(".jsonl")) return;
       pendingPaths.add(join(sessionsDir, name));
@@ -62,17 +101,19 @@ function ensureWatcher(): void {
     watcher.on("error", () => {
       watcher?.close();
       watcher = null;
+      scheduleRetry();
     });
   } catch {
     // No sessions directory yet, or the platform refused a recursive watch.
-    // Live updates degrade to the previous behaviour; nothing else breaks.
+    // Schedule a retry while subscribers remain; otherwise degrade silently.
     watcher = null;
+    scheduleRetry();
   }
 }
 
 export function subscribeSessionFileChanges(listener: Listener): () => void {
-  ensureWatcher();
   listeners.add(listener);
+  ensureWatcher();
   return () => {
     listeners.delete(listener);
     if (listeners.size > 0) return;
@@ -80,7 +121,12 @@ export function subscribeSessionFileChanges(listener: Listener): () => void {
       clearTimeout(flushTimer);
       flushTimer = null;
     }
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
     pendingPaths = new Set();
+    pendingUnknown = false;
     watcher?.close();
     watcher = null;
   };


### PR DESCRIPTION
## Problem

A session that `omp` writes from a terminal — or that a harness starts by launching `omp` — never updates while it is open in ompweb. The file grows, the transcript stays frozen, and you have to reload the page to see the turn that just landed.

The cause is that live updates are only wired to sessions ompweb spawns itself: `/api/agent/running/events` reports `getRunningRpcSessionIds()`, and nothing watches the session files. For an externally-owned session there is no RPC stream, so no signal exists that it advanced.

We hit this running omp under a wrapper: the session shows up in the sidebar and reads correctly, but watching a run means refreshing repeatedly.

## Change

- **`lib/session-watcher.ts`** — a debounced (250 ms) recursive watch of `<agentDir>/sessions`. On change it calls `invalidateSessionListCache()`, resolves the changed paths through `resolveSessionIdByPath`, and reports the session ids. Created on first subscribe, closed on last unsubscribe.
- **`app/api/agent/running/events/route.ts`** — forwards those ids as a `sessions-changed` frame alongside the existing `running` frames, with `refreshSessionList: true`.
- **`lib/session-change-bus.ts`** — a tiny in-process pub/sub, because the SSE is consumed by `SessionSidebar` while the open transcript lives in `useAgentSession` under a sibling component. This avoids threading a callback through `AppShell` and `ChatWindow`.
- **`SessionSidebar`** — on `sessions-changed`, reuses the existing 300 ms-debounced list refresh and republishes the ids.
- **`useAgentSession`** — reloads the open transcript when the changed ids include the current session **and no event stream is attached**, so a session ompweb owns keeps its RPC stream as the single authority and never sees a competing refetch.

## Notes on the approach

`/api/agent/[id]/events` looked like the natural place, but it calls `startRpcSession` on a cache miss — subscribing there for an externally-owned session would spawn a second `omp` against a JSONL the running `omp` already owns, which is exactly what the README warns about. Hence the global stream plus the ownership guard.

Failure is soft: if the sessions directory does not exist yet, or a platform refuses a recursive watch, the watcher stays `null` and behaviour is unchanged.

## Verification

Against a production build (`npm run build`), appending a line to a session file ompweb did **not** start:

```
data: {"type":"running","runningSessionIds":[]}
data: {"type":"sessions-changed","sessionIds":["01a0139b-c66b-7000-a3ee-09e7b0a23a25"],"refreshSessionList":true}
```

— naming exactly the session whose file changed.

`npm run typecheck` and `eslint` are clean. `npm test` passes with three new cases for the bus (fan-out, unsubscribe/empty batches, and a throwing subscriber not stopping others). One pre-existing failure is unrelated: `lib/worktree.test.mjs` fails on macOS before this change too, comparing `/var/...` against its `/private/var/...` realpath.

I deliberately did not add a test for the watcher itself — `fs.watch` tests are timing-dependent and I did not see a precedent for them in the suite. Happy to add one if you would like it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams live updates for sessions started outside the web UI by watching session files and forwarding changes over the running-events SSE. Previously, these sessions stayed frozen until a manual reload; now the sidebar refreshes and the open transcript reloads when their files grow, while RPC-owned sessions keep their stream as the single authority.

- Adds lib/session-watcher.ts: debounced (250 ms) recursive watch of <agentDir>/sessions; on change invalidates the session-list cache, resolves changed paths to session IDs, and notifies subscribers. Created on first subscribe and closed on last; hardened to retry on watch errors or missing dirs (5 s backoff) and to rescan on coalesced/overflow events.
- Updates app/api/agent/running/events/route.ts: subscribes to the watcher and emits {"type":"sessions-changed","sessionIds":[...],"refreshSessionList":true} frames alongside "running"; cleans up both subscriptions.
- Adds lib/session-change-bus.ts (+ tests): in-process pub/sub to relay changed IDs from the sidebar to useAgentSession; tests cover fan-out, unsubscribe/empty batches, and error isolation.
- Updates components/SessionSidebar.tsx: handles "sessions-changed", reuses the existing debounced list refresh, and republishes IDs on the bus.
- Updates hooks/useAgentSession.ts: on bus events, reloads the open transcript only when its ID changed and no event stream is attached (avoids competing refetches for RPC-owned sessions).
- Avoids using `/api/agent/[id]/events` because it starts an RPC session on cache miss, which could spawn a second `omp` on a file already owned by a running process.

<sup>Written for commit a5475f6342b861f8e1fead3ee01010434f2d96f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session lists now refresh automatically when session files change.
  * Active session transcripts update when modified externally.
  * Live updates identify affected sessions for faster, more targeted refreshes.

* **Bug Fixes**
  * Improved resilience when session monitoring encounters errors or unavailable directories.
  * Prevented duplicate refreshes and ensured updates continue if one listener fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->