### PR TITLE
feat(ui): show cache hit rate in session stats panel

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -11,7 +11,7 @@ import { ChatWindow } from "./ChatWindow";
 import { TabBar, type Tab } from "./TabBar";
 import { BranchNavigator } from "./BranchNavigator";
 import { LanguageSwitcher } from "./LanguageSwitcher";
-import { Check, History, Menu, Moon, PanelLeft, Sun, Terminal, Wand2 } from "lucide-react";
+import { Check, CircleCheck, History, Menu, Moon, PanelLeft, Sun, Terminal, Wand2 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { formatCompactNumber, formatPercent } from "@/lib/format";
 import { translate, useI18n } from "@/lib/i18n";
@@ -1098,8 +1098,8 @@ export function AppShell() {
               tooltipParts.push(t("appShell.tooltipOutput", { value: tok.output.toLocaleString(locale) }));
               tooltipParts.push(t("appShell.tooltipCacheRead", { value: tok.cacheRead.toLocaleString(locale) }));
               tooltipParts.push(t("appShell.tooltipCacheWrite", { value: tok.cacheWrite.toLocaleString(locale) }));
-              if (c > 0) tooltipParts.push(t("appShell.tooltipCost", { value: c.toFixed(4) }));
               if (cacheRateTopStr) tooltipParts.push(t("appShell.tooltipCacheRate", { percent: cacheRateTopStr }));
+              if (c > 0) tooltipParts.push(t("appShell.tooltipCost", { value: c.toFixed(4) }));
             }
             if (contextUsage?.contextWindow) {
               const pct = contextUsage.percent;
@@ -1178,6 +1178,7 @@ export function AppShell() {
                 )}
                 {!isMobile && cacheRateTopStr && (
                   <span style={{ display: "flex", alignItems: "center", gap: 4, color: "var(--text-muted)" }}>
+                    <CircleCheck size={12} strokeWidth={1.8} aria-hidden="true" />
                     {cacheRateTopStr}
                   </span>
                 )}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1182,6 +1182,14 @@ export function AppShell() {
                     {cacheRateTopStr}
                   </span>
                 )}
+                {ctxStr && (
+                  <span style={{ display: "flex", alignItems: "center", gap: 4, color: ctxColor, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    <svg width="12" height="12" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M1 9 L1 5 Q1 1 5 1 Q9 1 9 5 L9 9" /><line x1="1" y1="9" x2="9" y2="9" />
+                    </svg>
+                    {ctxStr}
+                  </span>
+                )}
                 {!isMobile && costStr && (
                   <span style={{ display: "flex", alignItems: "center", color: "var(--text)", fontWeight: 500 }}>
                     {costStr}
@@ -1195,14 +1203,6 @@ export function AppShell() {
                 {!isMobile && averageSpeedStr && (
                   <span style={{ display: "flex", alignItems: "center", gap: 4, color: "var(--text-muted)" }}>
                     {averageSpeedStr}
-                  </span>
-                )}
-                {ctxStr && (
-                  <span style={{ display: "flex", alignItems: "center", gap: 4, color: ctxColor, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    <svg width="12" height="12" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M1 9 L1 5 Q1 1 5 1 Q9 1 9 5 L9 9" /><line x1="1" y1="9" x2="9" y2="9" />
-                    </svg>
-                    {ctxStr}
                   </span>
                 )}
               </button>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1074,6 +1074,8 @@ export function AppShell() {
             const tok = sessionStats?.tokens;
             const c = sessionStats?.cost ?? 0;
             const costStr = c > 0 ? (c >= 0.01 ? `$${c.toFixed(2)}` : `<$0.01`) : null;
+            const cacheDenomTop = tok ? tok.input + tok.cacheRead : 0;
+            const cacheRateTopStr = tok && cacheDenomTop > 0 ? formatPercent((tok.cacheRead / cacheDenomTop) * 100) : null;
             const currentSpeedStr = generationSpeed?.current !== null && generationSpeed?.current !== undefined
               ? `${generationSpeed.current.toFixed(1)} t/s`
               : null;
@@ -1097,6 +1099,7 @@ export function AppShell() {
               tooltipParts.push(t("appShell.tooltipCacheRead", { value: tok.cacheRead.toLocaleString(locale) }));
               tooltipParts.push(t("appShell.tooltipCacheWrite", { value: tok.cacheWrite.toLocaleString(locale) }));
               if (c > 0) tooltipParts.push(t("appShell.tooltipCost", { value: c.toFixed(4) }));
+              if (cacheRateTopStr) tooltipParts.push(t("appShell.tooltipCacheRate", { percent: cacheRateTopStr }));
             }
             if (contextUsage?.contextWindow) {
               const pct = contextUsage.percent;
@@ -1171,6 +1174,11 @@ export function AppShell() {
                       <path d="M8.5 5a3.5 3.5 0 1 1-1-2.45" /><polyline points="6.5 1.5 8.5 2.5 7.5 4.5" />
                     </svg>
                     {formatCompactNumber(tok.cacheRead)}
+                  </span>
+                )}
+                {!isMobile && cacheRateTopStr && (
+                  <span style={{ display: "flex", alignItems: "center", gap: 4, color: "var(--text-muted)" }}>
+                    {cacheRateTopStr}
                   </span>
                 )}
                 {!isMobile && costStr && (

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1272,7 +1272,10 @@ export function AppShell() {
                       [t("appShell.statTotal"), sessionStats.tokens.total.toLocaleString(locale)],
                     ];
                     const ctx = contextUsage ?? sessionStats.contextUsage;
+                    const cacheInputDenom = sessionStats.tokens.input + sessionStats.tokens.cacheRead;
+                    const cacheRate = cacheInputDenom > 0 ? (sessionStats.tokens.cacheRead / cacheInputDenom) * 100 : 0;
                     const extraTokenRows = [
+                      [t("appShell.statCacheRate"), formatPercent(cacheRate)],
                       ...(sessionStats.cost > 0 ? [[t("appShell.statCost"), `$${sessionStats.cost.toFixed(4)}`]] : []),
                       ...(ctx?.contextWindow ? [[t("appShell.statContext"), `${ctx.percent !== null ? formatPercent(ctx.percent) : "?"} / ${formatCompactNumber(ctx.contextWindow)}`]] : []),
                     ];

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -137,6 +137,7 @@
   "appShell.tooltipCacheWrite": "cache write: {value}",
   "appShell.tooltipContext": "context: {percent} of {tokens} tokens",
   "appShell.tooltipCost": "cost: ${value}",
+  "appShell.tooltipCacheRate": "cache hit: {percent}",
   "appShell.tooltipInput": "in: {value}",
   "appShell.tooltipOutput": "out: {value}",
   "appShell.tooltipCurrentSpeed": "current: {value}",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -106,6 +106,7 @@
   "appShell.skills": "Skills",
   "appShell.statAssistant": "Assistant",
   "appShell.statCacheRead": "Cache Read",
+  "appShell.statCacheRate": "Cache Hit",
   "appShell.statCacheWrite": "Cache Write",
   "appShell.statContext": "Context",
   "appShell.statCost": "Cost",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -137,6 +137,7 @@
   "appShell.tooltipCacheWrite": "キャッシュ書き込み: {value}",
   "appShell.tooltipContext": "コンテキスト: {tokens} トークン中 {percent}",
   "appShell.tooltipCost": "コスト: ${value}",
+  "appShell.tooltipCacheRate": "キャッシュヒット: {percent}",
   "appShell.tooltipInput": "入力: {value}",
   "appShell.tooltipOutput": "出力: {value}",
   "appShell.tooltipCurrentSpeed": "現在: {value}",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -106,6 +106,7 @@
   "appShell.skills": "スキル",
   "appShell.statAssistant": "アシスタント",
   "appShell.statCacheRead": "キャッシュ読み取り",
+  "appShell.statCacheRate": "キャッシュヒット",
   "appShell.statCacheWrite": "キャッシュ書き込み",
   "appShell.statContext": "コンテキスト",
   "appShell.statCost": "コスト",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -137,6 +137,7 @@
   "appShell.tooltipCacheWrite": "缓存写入：{value}",
   "appShell.tooltipContext": "上下文：{percent}（共 {tokens} token）",
   "appShell.tooltipCost": "费用：${value}",
+  "appShell.tooltipCacheRate": "缓存命中：{percent}",
   "appShell.tooltipInput": "输入：{value}",
   "appShell.tooltipOutput": "输出：{value}",
   "appShell.tooltipCurrentSpeed": "当前：{value}",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -106,6 +106,7 @@
   "appShell.skills": "技能",
   "appShell.statAssistant": "助手",
   "appShell.statCacheRead": "缓存读取",
+  "appShell.statCacheRate": "缓存命中",
   "appShell.statCacheWrite": "缓存写入",
   "appShell.statContext": "上下文",
   "appShell.statCost": "费用",


### PR DESCRIPTION
Adds a cache hit rate row to the session stats panel (top-right of a conversation), placed ahead of the cost row.

- Formula: `cacheRead / (input + cacheRead)` — identical to `omp stats` `cacheRate`, computed from existing per-message usage fields (no new data plumbing).
- Always visible (0% until first cache hit) so the metric can be watched live.
- i18n keys added for en / zh-CN / ja.

Verified: `omp stats --json` reports `cacheRate: 0.9334` for `totalCacheReadTokens=29543936`, `totalInputTokens=2106773` → `29543936/(2106773+29543936)=0.9334` matches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a Cache Hit percentage in the session stats panel and top-bar to track cache effectiveness live. Previously neither view showed it; now both display Cache Hit ahead of Cost, and the top bar also moves Context ahead of Cost.

- Formula: cacheRead / (input + cacheRead), matching `omp stats` cacheRate; computed from existing usage fields (no new data paths).
- Panel: always shows a Cache Hit row (0% until any input or cache-read tokens).
- Top bar: shows Cache Hit with `CircleCheck` and adds a tooltip entry when input+cacheRead > 0; order is tokens → Cache Hit → Context → Cost.
- i18n: adds `appShell.statCacheRate` and `appShell.tooltipCacheRate` in en, zh-CN, and ja.

<sup>Written for commit 7dce1c02b18cd9f1811f609c21ad0305264feac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Cache Hit” percentage to the session statistics dropdown.
  * The cache-hit rate appears alongside existing token, cost, and context details.
  * Added localized labels for English, Japanese, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->