### PR TITLE
feat(cli): display accessible network addresses and fix 0.0.0.0 browser launch

### DIFF
--- a/bin/network-addresses.js
+++ b/bin/network-addresses.js
@@ -1,0 +1,190 @@
+"use strict";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const os = require("os");
+
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+const WILDCARD_HOSTNAMES = new Set(["0.0.0.0", "::", "0:0:0:0:0:0:0:0", ""]);
+
+function isWildcardHost(hostname) {
+  return !hostname || WILDCARD_HOSTNAMES.has(String(hostname).trim());
+}
+
+function isLoopbackHost(hostname) {
+  return typeof hostname === "string" && LOOPBACK_HOSTNAMES.has(hostname.trim().toLowerCase());
+}
+
+function getBrowserUrl(hostname, port) {
+  if (isWildcardHost(hostname)) {
+    return `http://localhost:${port}`;
+  }
+  return `http://${hostname}:${port}`;
+}
+
+function isTailscaleAddress(ifaceName, address) {
+  if (typeof ifaceName === "string" && ifaceName.toLowerCase().includes("tailscale")) {
+    return true;
+  }
+  // Tailscale IPv4 uses CGNAT range 100.64.0.0/10 (100.64.0.0 to 100.127.255.255)
+  if (typeof address === "string") {
+    const parts = address.split(".").map(Number);
+    if (parts.length === 4 && parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isIgnoredAddress(ifaceName, address) {
+  if (!address || typeof address !== "string") return true;
+  // APIPA (Automatic Private IP Addressing: 169.254.0.0/16)
+  if (address.startsWith("169.254.")) return true;
+  // RFC 2544 benchmark / TUN proxy fake-ip range (198.18.0.0/15)
+  if (/^198\.(18|19)\./.test(address)) return true;
+  // Loopback
+  if (address.startsWith("127.")) return true;
+  return false;
+}
+
+function isVirtualBridge(ifaceName) {
+  if (!ifaceName || typeof ifaceName !== "string") return false;
+  const name = ifaceName.toLowerCase();
+  return (
+    name.includes("vethernet") ||
+    name.includes("veth") ||
+    name.includes("wsl") ||
+    name.includes("docker") ||
+    name.includes("hyper-v") ||
+    name.includes("vmware") ||
+    name.includes("virtualbox") ||
+    name.includes("virbr")
+  );
+}
+
+function isStandardPhysicalInterface(name) {
+  if (!name || typeof name !== "string") return false;
+  if (isVirtualBridge(name)) return false;
+  const lower = name.toLowerCase();
+  return (
+    lower.includes("以太网") ||
+    lower.includes("ethernet") ||
+    lower.includes("wi-fi") ||
+    lower.includes("wifi") ||
+    lower.includes("wlan") ||
+    lower.includes("无线") ||
+    /^en\d+$/.test(lower) ||
+    /^eth\d+$/.test(lower) ||
+    /^wlan\d+$/.test(lower) ||
+    /^enp\d+s\d+/.test(lower) ||
+    /^wlp\d+s\d+/.test(lower)
+  );
+}
+
+function getAccessibleAddresses({ hostname, port, interfaces = os.networkInterfaces() }) {
+  if (isLoopbackHost(hostname)) {
+    return {
+      entries: [{ label: "Local", url: `http://localhost:${port}` }],
+      hint: "use -H 0.0.0.0 to expose to the network",
+    };
+  }
+
+  if (!isWildcardHost(hostname)) {
+    return {
+      entries: [{ label: "Network", url: `http://${hostname}:${port}` }],
+    };
+  }
+
+  const entries = [{ label: "Local", url: `http://localhost:${port}` }];
+  const lanEntries = [];
+  const tailscaleEntries = [];
+  const otherEntries = [];
+  const seenAddresses = new Set(["127.0.0.1", "localhost"]);
+
+  for (const [name, addrs] of Object.entries(interfaces)) {
+    if (!addrs || !Array.isArray(addrs)) continue;
+    for (const info of addrs) {
+      if (info.family !== "IPv4" && info.family !== 4) continue;
+      if (info.internal) continue;
+      const addr = info.address;
+      if (seenAddresses.has(addr)) continue;
+      if (isIgnoredAddress(name, addr)) continue;
+
+      seenAddresses.add(addr);
+
+      if (isTailscaleAddress(name, addr)) {
+        tailscaleEntries.push({
+          label: "Tailscale",
+          url: `http://${addr}:${port}`,
+          name,
+          address: addr,
+        });
+      } else if (isStandardPhysicalInterface(name)) {
+        lanEntries.push({
+          label: "Network",
+          url: `http://${addr}:${port}`,
+          name,
+          address: addr,
+        });
+      } else {
+        otherEntries.push({
+          label: name,
+          url: `http://${addr}:${port}`,
+          name,
+          address: addr,
+        });
+      }
+    }
+  }
+
+  entries.push(...lanEntries, ...tailscaleEntries, ...otherEntries);
+  return { entries };
+}
+
+function formatAddressBanner({
+  version = "0.0.0",
+  entries = [],
+  hint,
+  passwordEnabled = false,
+  isTTY = process.stdout.isTTY,
+}) {
+  const dim = isTTY ? (s) => `\x1b[90m${s}\x1b[0m` : (s) => s;
+  const bold = isTTY ? (s) => `\x1b[1m${s}\x1b[0m` : (s) => s;
+  const green = isTTY ? (s) => `\x1b[32m${s}\x1b[0m` : (s) => s;
+  const cyan = isTTY ? (s) => `\x1b[36m${s}\x1b[0m` : (s) => s;
+
+  const lines = [];
+  lines.push("");
+  lines.push(`  ${bold("ompweb")} ${dim(`v${version}`)} ${green("is ready")}`);
+  lines.push("");
+
+  const maxLabelLen = Math.max(...entries.map((e) => e.label.length), hint ? 7 : 5);
+  for (const entry of entries) {
+    const padLabel = (entry.label + ":").padEnd(maxLabelLen + 2, " ");
+    lines.push(`  ${green("➜")}  ${bold(padLabel)} ${cyan(entry.url)}`);
+  }
+
+  if (hint) {
+    const padLabel = ("Network:").padEnd(maxLabelLen + 2, " ");
+    lines.push(`  ${dim("➜")}  ${dim(padLabel)} ${dim(hint)}`);
+  }
+
+  if (passwordEnabled) {
+    lines.push("");
+    lines.push(`  ${dim("🔒 Password protection enabled (OMP_WEB_PASSWORD)")}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+module.exports = {
+  isWildcardHost,
+  isLoopbackHost,
+  getBrowserUrl,
+  isTailscaleAddress,
+  isIgnoredAddress,
+  isStandardPhysicalInterface,
+  isVirtualBridge,
+  getAccessibleAddresses,
+  formatAddressBanner,
+};

--- a/bin/omp-web.js
+++ b/bin/omp-web.js
@@ -21,6 +21,8 @@ const { parseLaunchOptions } = require("./omp-web-options");
 const { isPortAvailable } = require("./port-availability");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { wireChildProcessLifecycle } = require("./process-lifecycle");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { getAccessibleAddresses, getBrowserUrl, formatAddressBanner, isLoopbackHost } = require("./network-addresses");
 
 const pkgDir = path.join(__dirname, "..");
 const nextDir = path.join(pkgDir, ".next");
@@ -40,6 +42,13 @@ try {
   }
 }
 
+let pkgVersion = "0.0.0";
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pkg = require("../package.json");
+  pkgVersion = pkg.version ?? "0.0.0";
+} catch { /* ignore */ }
+
 const launchOptions = parseLaunchOptions();
 if (launchOptions.help || launchOptions.version) {
   process.exit(0);
@@ -50,15 +59,13 @@ const password = launchOptions.password;
 const openBrowser = launchOptions.openBrowser;
 // Propagate --password into the env for proxy.ts / lib/web-auth.ts and the spawned Next process.
 if (password) process.env.OMP_WEB_PASSWORD = password;
-const loopbackHostnames = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 const passwordEnabled = typeof password === "string" && password.length > 0;
-
 if (!fs.existsSync(nextDir)) {
   console.error("Build artifacts not found. Please report this issue.");
   process.exit(1);
 }
 
-if (!loopbackHostnames.has(hostname)) {
+if (!isLoopbackHost(hostname)) {
   if (!passwordEnabled) {
     console.error(`Refusing to listen on ${hostname} without OMP_WEB_PASSWORD (or --password). Set a strong password or bind to 127.0.0.1.`);
     process.exit(1);
@@ -71,12 +78,11 @@ nextArgs.push("-H", hostname);
 
 // Always run next's JS entry with node directly — avoids .bin symlink issues
 // and path-with-spaces problems on Windows when shell: true is used.
-const url = `http://${hostname}:${port}`;
-
+const browserUrl = getBrowserUrl(hostname, port);
 async function main() {
   if (!await isPortAvailable(port, hostname)) {
     console.error(`Port ${port} on ${hostname} is already in use.`);
-    console.error(`If ompweb is already running, open ${url}. Otherwise, stop the process using it or run: ompweb --port ${Number(port) + 1}`);
+    console.error(`If ompweb is already running, open ${browserUrl}. Otherwise, stop the process using it or run: ompweb --port ${Number(port) + 1}`);
     process.exitCode = 1;
     return;
   }
@@ -94,30 +100,45 @@ async function main() {
   });
   wireChildProcessLifecycle(child);
 
+  let bannerPrinted = false;
   let browserOpened = false;
   child.stdout.on("data", (chunk) => {
     const text = chunk.toString();
     process.stdout.write(text);
-    if (openBrowser && !browserOpened && text.includes("Ready")) {
-      browserOpened = true;
-      const isWindows = process.platform === "win32";
-      const isMac = process.platform === "darwin";
-      const openCmd = isWindows ? "explorer.exe" : isMac ? "open" : "xdg-open";
-      const opener = spawn(openCmd, [url], {
-        stdio: "ignore",
-        detached: true,
-      });
+    if (text.includes("Ready")) {
+      if (!bannerPrinted) {
+        bannerPrinted = true;
+        const { entries, hint } = getAccessibleAddresses({ hostname, port });
+        const banner = formatAddressBanner({
+          version: pkgVersion,
+          entries,
+          hint,
+          passwordEnabled,
+          isTTY: process.stdout.isTTY,
+        });
+        process.stdout.write(banner);
+      }
+      if (openBrowser && !browserOpened) {
+        browserOpened = true;
+        const isWindows = process.platform === "win32";
+        const isMac = process.platform === "darwin";
+        const openCmd = isWindows ? "explorer.exe" : isMac ? "open" : "xdg-open";
+        const opener = spawn(openCmd, [browserUrl], {
+          stdio: "ignore",
+          detached: true,
+        });
 
-      opener.on("error", (error) => {
-        console.warn(`Could not open browser automatically: ${error.message}`);
-      });
+        opener.on("error", (error) => {
+          console.warn(`Could not open browser automatically: ${error.message}`);
+        });
 
-      opener.unref();
+        opener.unref();
+      }
     }
   });
 }
 
 main().catch((error) => {
-  console.error(`Could not check whether ${url} is available: ${error.message}`);
+  console.error(`Could not check whether ${browserUrl} is available: ${error.message}`);
   process.exit(1);
 });

--- a/lib/network-addresses.test.mjs
+++ b/lib/network-addresses.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  isWildcardHost,
+  isLoopbackHost,
+  getBrowserUrl,
+  isTailscaleAddress,
+  isIgnoredAddress,
+  getAccessibleAddresses,
+  formatAddressBanner,
+} = require("../bin/network-addresses.js");
+
+test("identifies wildcard hostnames", () => {
+  assert.equal(isWildcardHost("0.0.0.0"), true);
+  assert.equal(isWildcardHost("::"), true);
+  assert.equal(isWildcardHost("0:0:0:0:0:0:0:0"), true);
+  assert.equal(isWildcardHost(""), true);
+  assert.equal(isWildcardHost(undefined), true);
+  assert.equal(isWildcardHost(null), true);
+
+  assert.equal(isWildcardHost("127.0.0.1"), false);
+  assert.equal(isWildcardHost("localhost"), false);
+  assert.equal(isWildcardHost("192.168.1.1"), false);
+});
+
+test("identifies loopback hostnames", () => {
+  assert.equal(isLoopbackHost("127.0.0.1"), true);
+  assert.equal(isLoopbackHost("localhost"), true);
+  assert.equal(isLoopbackHost("LOCALHOST"), true);
+  assert.equal(isLoopbackHost("::1"), true);
+  assert.equal(isLoopbackHost("[::1]"), true);
+
+  assert.equal(isLoopbackHost("0.0.0.0"), false);
+  assert.equal(isLoopbackHost("192.168.1.1"), false);
+  assert.equal(isLoopbackHost(""), false);
+  assert.equal(isLoopbackHost(undefined), false);
+});
+
+test("safely resolves browser url avoiding 0.0.0.0", () => {
+  assert.equal(getBrowserUrl("0.0.0.0", "59002"), "http://localhost:59002");
+  assert.equal(getBrowserUrl("::", "59002"), "http://localhost:59002");
+  assert.equal(getBrowserUrl(undefined, "59002"), "http://localhost:59002");
+  assert.equal(getBrowserUrl("127.0.0.1", "30177"), "http://127.0.0.1:30177");
+  assert.equal(getBrowserUrl("localhost", "30177"), "http://localhost:30177");
+  assert.equal(getBrowserUrl("192.168.31.23", "59002"), "http://192.168.31.23:59002");
+});
+
+test("identifies Tailscale interface or CGNAT IP range", () => {
+  assert.equal(isTailscaleAddress("Tailscale", "169.254.1.1"), true);
+  assert.equal(isTailscaleAddress("tailscale0", "10.0.0.1"), true);
+  assert.equal(isTailscaleAddress("utun4", "100.80.12.34"), true);
+  assert.equal(isTailscaleAddress("Ethernet", "100.64.0.1"), true);
+  assert.equal(isTailscaleAddress("Ethernet", "100.127.255.254"), true);
+
+  assert.equal(isTailscaleAddress("Ethernet", "100.63.255.255"), false);
+  assert.equal(isTailscaleAddress("Ethernet", "100.128.0.1"), false);
+  assert.equal(isTailscaleAddress("Ethernet", "192.168.1.1"), false);
+});
+
+test("filters out ignored addresses like APIPA and TUN fake-ip", () => {
+  assert.equal(isIgnoredAddress("Tailscale", "169.254.83.107"), true);
+  assert.equal(isIgnoredAddress("Meta", "198.18.0.1"), true);
+  assert.equal(isIgnoredAddress("Clash", "198.19.0.5"), true);
+  assert.equal(isIgnoredAddress("Loopback", "127.0.0.1"), true);
+
+  assert.equal(isIgnoredAddress("Ethernet", "192.168.31.23"), false);
+  assert.equal(isIgnoredAddress("Tailscale", "100.80.12.34"), false);
+  assert.equal(isIgnoredAddress("Wi-Fi", "10.0.0.15"), false);
+});
+
+test("getAccessibleAddresses formats loopback binding properly", () => {
+  const result = getAccessibleAddresses({ hostname: "127.0.0.1", port: "30177" });
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].label, "Local");
+  assert.equal(result.entries[0].url, "http://localhost:30177");
+  assert.ok(result.hint?.includes("0.0.0.0"));
+});
+
+test("getAccessibleAddresses extracts and categorizes multi-interface 0.0.0.0 binding", () => {
+  const mockInterfaces = {
+    "Loopback": [
+      { address: "127.0.0.1", family: "IPv4", internal: true },
+    ],
+    "Meta (TUN)": [
+      { address: "198.18.0.1", family: "IPv4", internal: false },
+    ],
+    "Tailscale": [
+      { address: "169.254.83.107", family: "IPv4", internal: false },
+      { address: "100.80.12.34", family: "IPv4", internal: false },
+    ],
+    "Ethernet": [
+      { address: "192.168.31.23", family: "IPv4", internal: false },
+    ],
+    "vEthernet (WSL)": [
+      { address: "172.18.16.1", family: "IPv4", internal: false },
+    ],
+  };
+
+  const result = getAccessibleAddresses({
+    hostname: "0.0.0.0",
+    port: "59002",
+    interfaces: mockInterfaces,
+  });
+
+  assert.equal(result.entries.length, 4);
+
+  const local = result.entries.find((e) => e.label === "Local");
+  assert.ok(local);
+  assert.equal(local.url, "http://localhost:59002");
+
+  const lan = result.entries.find((e) => e.label === "Network" && e.address === "192.168.31.23");
+  assert.ok(lan);
+  assert.equal(lan.url, "http://192.168.31.23:59002");
+
+  const ts = result.entries.find((e) => e.label === "Tailscale" && e.address === "100.80.12.34");
+  assert.ok(ts);
+  assert.equal(ts.url, "http://100.80.12.34:59002");
+
+  const wsl = result.entries.find((e) => e.address === "172.18.16.1");
+  assert.ok(wsl);
+
+  // 198.18.0.1 and 169.254.83.107 should NOT be present
+  assert.equal(result.entries.some((e) => e.address === "198.18.0.1"), false);
+  assert.equal(result.entries.some((e) => e.address === "169.254.83.107"), false);
+});
+
+test("formatAddressBanner generates readable output with status indicators", () => {
+  const banner = formatAddressBanner({
+    version: "0.3.5",
+    entries: [
+      { label: "Local", url: "http://localhost:59002" },
+      { label: "Network", url: "http://192.168.31.23:59002" },
+    ],
+    passwordEnabled: true,
+    isTTY: false,
+  });
+
+  assert.ok(banner.includes("ompweb"));
+  assert.ok(banner.includes("v0.3.5"));
+  assert.ok(banner.includes("is ready"));
+  assert.ok(banner.includes("Local:"));
+  assert.ok(banner.includes("http://localhost:59002"));
+  assert.ok(banner.includes("Network:"));
+  assert.ok(banner.includes("http://192.168.31.23:59002"));
+  assert.ok(banner.includes("OMP_WEB_PASSWORD"));
+});


### PR DESCRIPTION
### Summary
- **Network Address Banner**: Automatically detects available IPv4 network interfaces on startup and prints a structured, readable list of accessible endpoints (`Local`, `Network (LAN)`, `Tailscale`, and named virtual interfaces).
- **Safe Browser Launch**: Resolves the wildcard bind address (`0.0.0.0` / `::`) to `http://localhost:<port>` when auto-opening the default browser, preventing 502 Bad Gateway errors caused by browsers or proxies intercepting `0.0.0.0`.
- **Address Filtering**: Excludes unassigned APIPA addresses (`169.254.0.0/16`) and proxy TUN/fake-IP ranges (`198.18.0.0/15`).

### Testing
- Added unit test suite `lib/network-addresses.test.mjs` covering loopback detection, wildcard handling, Tailscale CGNAT classification, address filtering, and banner formatting.
- Ran full test suite: 396/396 tests passed, TypeScript typecheck and linting passed cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Displays accessible network addresses at startup and fixes auto-open when bound to a wildcard host. Previously the CLI launched the browser at http://0.0.0.0:<port> (often failing); now it opens http://localhost:<port> and prints Local, Network, and Tailscale URLs.

- New `bin/network-addresses.js` detects IPv4 interfaces, filters APIPA (`169.254.0.0/16`) and `198.18.0.0/15`, categorizes Tailscale (name match or `100.64.0.0/10`), common LAN interfaces, and other virtual bridges, then formats a single “ready” banner with version and optional password hint.
- `bin/omp-web.js` resolves the browser target via `getBrowserUrl` and prints the banner once when Next logs “Ready”; password requirements for non-loopback hosts are unchanged.
- Adds `lib/network-addresses.test.mjs` covering wildcard/loopback resolution, filtering, Tailscale detection, and banner formatting.

<sup>Written for commit 39fb76ca41a78759d834594516257f8105781b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

