### PR TITLE
fix(runtime): harden prompt state reconciliation, bound RPC timeouts, and fix SSE cleanup

### DIFF
--- a/app/api/agent/[id]/events/route.ts
+++ b/app/api/agent/[id]/events/route.ts
@@ -23,6 +23,7 @@ export async function GET(
   const stream = new ReadableStream({
     start(controller) {
       let closed = false;
+      let cleaned = false;
       let unsubscribe: (() => void) | null = null;
       // Backpressure slot: while the consumer is behind (desiredSize < 0),
       // replaceable `message_update` frames collapse to the latest one (omp
@@ -30,16 +31,40 @@ export async function GET(
       // Control/terminal frames are small and never dropped; they flush the
       // pending update first so ordering is preserved.
       let pendingUpdate: unknown | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+      const cleanup = () => {
+        if (cleaned) return;
+        closed = true;
+        cleaned = true;
+        pendingUpdate = null;
+        if (heartbeatTimer !== null) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+        if (unsubscribe) {
+          try { unsubscribe(); } catch {}
+          unsubscribe = null;
+        }
+        req.signal?.removeEventListener("abort", cleanup);
+        try {
+          controller.close();
+        } catch {
+          // controller already closed
+        }
+      };
+      streamCleanup = cleanup;
 
       const flushPendingUpdate = (): boolean => {
         const data = pendingUpdate;
         pendingUpdate = null;
         if (data === null) return true;
+        if (closed) return false;
         try {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
           return true;
         } catch {
-          closed = true;
+          cleanup();
           return false;
         }
       };
@@ -56,33 +81,20 @@ export async function GET(
         try {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
         } catch {
-          closed = true;
+          cleanup();
         }
       };
 
       // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s)
-      const heartbeat = setInterval(() => {
+      heartbeatTimer = setInterval(() => {
         if (closed) return;
         if (!flushPendingUpdate()) return;
         try {
           controller.enqueue(encoder.encode(":\n\n"));
         } catch {
-          closed = true;
+          cleanup();
         }
       }, 30_000);
-
-      const cleanup = () => {
-        if (closed) return;
-        closed = true;
-        clearInterval(heartbeat);
-        unsubscribe?.();
-        try {
-          controller.close();
-        } catch {
-          // controller already closed
-        }
-      };
-      streamCleanup = cleanup;
 
       // Detect client disconnect via abort signal
       req.signal?.addEventListener("abort", cleanup);
@@ -99,7 +111,6 @@ export async function GET(
       streamCleanup?.();
     },
   });
-
   return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",

--- a/app/api/agent/[id]/route.ts
+++ b/app/api/agent/[id]/route.ts
@@ -84,9 +84,15 @@ export async function GET(
     if (!session || !session.isAlive()) {
       return NextResponse.json({ running: false });
     }
-
-    const state = await session.send({ type: "get_state" });
-    return NextResponse.json({ running: true, state });
+    try {
+      const state = await session.send({ type: "get_state" });
+      return NextResponse.json({ running: true, state });
+    } catch (error) {
+      if (error instanceof WebRpcError && error.code === "session_unresponsive") {
+        return NextResponse.json({ running: false, recovered: true });
+      }
+      throw error;
+    }
   } catch (error) {
     return commandErrorResponse(error);
   }

--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -10,65 +10,83 @@ export async function GET(req: Request) {
   // Hoisted so the stream's cancel() (half-open disconnects that never fire
   // the abort signal) can release the heartbeat and the subscriber.
   let streamCleanup: (() => void) | null = null;
+  const encoder = new TextEncoder();
+
   const stream = new ReadableStream({
     start(controller) {
-      const encode = (data: unknown) => {
-        const text = `data: ${JSON.stringify(data)}\n\n`;
-        controller.enqueue(new TextEncoder().encode(text));
-      };
-
-      // Subscribe BEFORE taking the initial snapshot so no state change can slip
-      // through the gap between snapshot and subscription.
-      const unsubscribe = subscribeRunningSessions(({ ids, refreshSessionList }) => {
-        try {
-          encode({
-            type: "running",
-            runningSessionIds: ids,
-            ...(refreshSessionList ? { refreshSessionList: true } : {}),
-          });
-        } catch {
-          // controller already closed
-        }
-      });
-
-      // Sessions omp writes outside the web UI produce no RPC events, so the
-      // only signal that they advanced is the file itself.
-      const holder: { fn: (() => void) | null } = { fn: null };
-      holder.fn = subscribeSessionFileChanges((sessionIds) => {
-        try {
-          encode({ type: "sessions-changed", sessionIds, refreshSessionList: true });
-        } catch {
-          try { holder.fn?.(); } catch { /* already cleaned up */ }
-        }
-      });
-      const unsubscribeFiles = holder.fn;
-
-      // Initial snapshot so the client renders the correct state immediately.
-      // (A duplicate frame here is harmless: the client just sets the same set.)
-      encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
-
-      // Heartbeat to keep the connection alive through proxies/timeouts.
-      const heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(new TextEncoder().encode(":\n\n"));
-        } catch {
-          // controller already closed
-        }
-      }, 30_000);
+      let closed = false;
+      let cleaned = false;
+      let unsubscribeRunning: (() => void) | null = null;
+      let unsubscribeFiles: (() => void) | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
       const cleanup = () => {
-        clearInterval(heartbeat);
-        unsubscribe();
-        unsubscribeFiles();
-        try { controller.close(); } catch { /* already closed */ }
+        if (cleaned) return;
+        closed = true;
+        cleaned = true;
+        if (heartbeatTimer !== null) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+        if (unsubscribeRunning) {
+          try { unsubscribeRunning(); } catch {}
+          unsubscribeRunning = null;
+        }
+        if (unsubscribeFiles) {
+          try { unsubscribeFiles(); } catch {}
+          unsubscribeFiles = null;
+        }
+        req.signal?.removeEventListener("abort", cleanup);
+        try {
+          controller.close();
+        } catch {
+          // controller already closed
+        }
       };
       streamCleanup = cleanup;
+
+      const encode = (data: unknown) => {
+        if (closed) return;
+        try {
+          const text = `data: ${JSON.stringify(data)}\n\n`;
+          controller.enqueue(encoder.encode(text));
+        } catch {
+          cleanup();
+        }
+      };
 
       req.signal?.addEventListener("abort", cleanup);
       if (req.signal?.aborted) {
         cleanup();
         return;
       }
+
+      // Subscribe BEFORE taking the initial snapshot so no state change can slip
+      // through the gap between snapshot and subscription.
+      unsubscribeRunning = subscribeRunningSessions(({ ids, refreshSessionList }) => {
+        encode({
+          type: "running",
+          runningSessionIds: ids,
+          ...(refreshSessionList ? { refreshSessionList: true } : {}),
+        });
+      });
+
+      unsubscribeFiles = subscribeSessionFileChanges((sessionIds) => {
+        encode({ type: "sessions-changed", sessionIds, refreshSessionList: true });
+      });
+
+      // Initial snapshot so the client renders the correct state immediately.
+      encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
+
+      // Heartbeat to keep the connection alive through proxies/timeouts.
+      heartbeatTimer = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(":\n\n"));
+        } catch {
+          cleanup();
+        }
+      }, 30_000);
     },
     cancel() {
       streamCleanup?.();

--- a/app/api/omp-update/route.ts
+++ b/app/api/omp-update/route.ts
@@ -6,8 +6,8 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json() as { action?: unknown };
-    if (body.action === "check") return NextResponse.json(await checkOmpUpdate());
+    const body = await request.json() as { action?: unknown; force?: boolean };
+    if (body.action === "check") return NextResponse.json(await checkOmpUpdate(body.force === true));
     if (body.action === "update") {
       return NextResponse.json({ error: "Automatic self-updating is disabled. Run 'omp update' in your terminal.", code: "update_disabled" }, { status: 400 });
     }

--- a/app/api/sessions/[id]/state/route.ts
+++ b/app/api/sessions/[id]/state/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getRpcSession } from "@/lib/rpc-manager";
+import { getRpcSession, WebRpcError } from "@/lib/rpc-manager";
 import { apiErrorResponse, resolveSessionPathOr404 } from "@/lib/api-utils";
 
 export async function GET(
@@ -13,8 +13,15 @@ export async function GET(
     // below would 404 a brand-new running session.
     const rpc = getRpcSession(id);
     if (rpc?.isAlive()) {
-      const state = await rpc.send({ type: "get_state" });
-      return NextResponse.json({ running: true, state });
+      try {
+        const state = await rpc.send({ type: "get_state" });
+        return NextResponse.json({ running: true, state });
+      } catch (error) {
+        if (error instanceof WebRpcError && error.code === "session_unresponsive") {
+          return NextResponse.json({ running: false, recovered: true });
+        }
+        throw error;
+      }
     }
 
     const resolved = await resolveSessionPathOr404(id);

--- a/components/SettingsConfig.tsx
+++ b/components/SettingsConfig.tsx
@@ -428,11 +428,11 @@ export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCal
     void saveNativeSettings({ ...base, tools: { ...tools, approval: { ...(tools.approval ?? {}), ...patch } } });
   }, [nativeSettings, saveNativeSettings]);
 
-  const checkForUpdate = useCallback(async () => {
+  const checkForUpdate = useCallback(async (force = false) => {
     setChecking(true);
     setMessage(null);
     try {
-      const response = await fetch("/api/omp-update", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "check", force: true }) });
+      const response = await fetch("/api/omp-update", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "check", ...(force ? { force: true } : {}) }) });
       const data = (await response.json()) as UpdateState & { error?: string };
       if (!response.ok || data.error) throw new Error(data.error || `HTTP ${response.status}`);
       setUpdate(data);
@@ -994,7 +994,7 @@ export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCal
                         {checking ? t("settingsConfig.checkingUpdates") : update?.updateAvailable ? t("appShell.updateVersion", { current: update.currentVersion ?? "?", available: update.availableVersion ?? "?" }) : update?.currentVersion ? t("settingsConfig.upToDate", { version: update.currentVersion }) : t("settingsConfig.versionUnavailable")}
                       </div>
                     </div>
-                    <button type="button" onClick={() => void checkForUpdate()} disabled={checking} aria-label={t("settingsConfig.checkOmpUpdates")} style={{ padding: "6px 10px", border: "1px solid var(--border)", borderRadius: "var(--radius-control)", background: "transparent", color: "var(--text)", cursor: checking ? "wait" : "pointer", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 5 }}>
+                    <button type="button" onClick={() => void checkForUpdate(true)} disabled={checking} aria-label={t("settingsConfig.checkOmpUpdates")} style={{ padding: "6px 10px", border: "1px solid var(--border)", borderRadius: "var(--radius-control)", background: "transparent", color: "var(--text)", cursor: checking ? "wait" : "pointer", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 5 }}>
                       <RefreshCw size={13} aria-hidden="true" /> {t("settingsConfig.refresh")}
                     </button>
                   </div>

--- a/components/SettingsConfig.tsx
+++ b/components/SettingsConfig.tsx
@@ -432,7 +432,7 @@ export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCal
     setChecking(true);
     setMessage(null);
     try {
-      const response = await fetch("/api/omp-update", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "check" }) });
+      const response = await fetch("/api/omp-update", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "check", force: true }) });
       const data = (await response.json()) as UpdateState & { error?: string };
       if (!response.ok || data.error) throw new Error(data.error || `HTTP ${response.status}`);
       setUpdate(data);

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -2447,6 +2447,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const sid = sessionIdRef.current;
     if (!sid || !agentRunningRef.current) return false;
 
+    clearTerminalReconcileTimer();
+    // Advance the run generation so late agent_end / prompt_error / stale
+    // loadSession from the aborted turn cannot stop or clobber the replacement.
+    promptRunIdRef.current += 1;
+
     const { userMsg, piImages: interruptPiImages } = buildOutgoingPrompt(message, images);
     setMessages((prev) => [...prev, userMsg]);
     optimisticUserMessageKeyRef.current = userMessageKey(userMsg);
@@ -2479,7 +2484,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       addNotice({ type: "error", message: e instanceof Error ? e.message : String(e) });
       return false;
     }
-  }, [addNotice, ensureEventsConnected, refreshSubagentRoster]);
+  }, [addNotice, ensureEventsConnected, refreshSubagentRoster, clearTerminalReconcileTimer]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -656,6 +656,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   useEffect(() => () => {
     clearTerminalReconcileTimer();
   }, [clearTerminalReconcileTimer]);
+  // Blocks prompt submission while the initial hydration's live-state fetch is
+  // still pending. Without this, showLoading=false after disk messages lets
+  // a prompt increment runId before the stale pre-prompt state arrives and
+  // clobbers the new run's derived state (model/fast-mode).
+  const initialHydrationPendingRef = useRef(false);
   const [extensionCustomUi, setExtensionCustomUi] = useState<ExtensionUiCustomRequest | null>(null);
   const [extensionStatuses, setExtensionStatuses] = useState<ExtensionStatusItem[]>([]);
   const [extensionWidgets, setExtensionWidgets] = useState<ExtensionWidgetItem[]>([]);
@@ -1049,6 +1054,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         return null;
       }
 
+      // Track initial hydration so prompt submission waits for the live state.
+      const isInitialHydration = showLoading && includeState;
+      if (isInitialHydration) initialHydrationPendingRef.current = true;
+
       try {
         // Capture the sequence token BEFORE the fetch: a response snapshotted
         // earlier must not mint a fresh token on arrival and clobber a newer
@@ -1092,12 +1101,17 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         console.error("Failed to load agent state:", e);
         if (showLoading) setLoading(false);
         return null;
+      } finally {
+        if (isInitialHydration) initialHydrationPendingRef.current = false;
       }
     } catch (e) {
       setError(String(e));
+      if (showLoading && includeState) initialHydrationPendingRef.current = false;
       return null;
     } finally {
       if (showLoading && !messagesLoaded) setLoading(false);
+      // Ensure the flag is cleared even if the pre-state early-return path was taken
+      if (showLoading && includeState && !messagesLoaded) initialHydrationPendingRef.current = false;
     }
   }, [refreshSubagentHistory, applyAuthoritativeModel, beginAuthoritativeModelSync]);
 
@@ -2317,6 +2331,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const trimmedMessage = message.trim();
     if (!trimmedMessage && !images?.length) return false;
     if (agentRunningRef.current || bashRunningRef.current) return false;
+    if (initialHydrationPendingRef.current) return false;
     const isSlashCommandPrompt = !images?.length && trimmedMessage.startsWith("/");
 
     const isBashCommand = !images?.length && trimmedMessage.startsWith("!");

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -646,6 +646,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   useEffect(() => () => {
     if (extensionDialogClearTimerRef.current) clearTimeout(extensionDialogClearTimerRef.current);
   }, []);
+  const terminalReconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearTerminalReconcileTimer = useCallback(() => {
+    if (terminalReconcileTimerRef.current) {
+      clearTimeout(terminalReconcileTimerRef.current);
+      terminalReconcileTimerRef.current = null;
+    }
+  }, []);
+  useEffect(() => () => {
+    clearTerminalReconcileTimer();
+  }, [clearTerminalReconcileTimer]);
   const [extensionCustomUi, setExtensionCustomUi] = useState<ExtensionUiCustomRequest | null>(null);
   const [extensionStatuses, setExtensionStatuses] = useState<ExtensionStatusItem[]>([]);
   const [extensionWidgets, setExtensionWidgets] = useState<ExtensionWidgetItem[]>([]);
@@ -1034,8 +1044,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       }
 
       messagesLoaded = true;
+      if (showLoading) setLoading(false);
       if (!includeState) {
-        if (showLoading) setLoading(false);
         return null;
       }
 
@@ -1642,6 +1652,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [addNotice, opts.chatInputRef]);
 
   const finishPromptWithoutStream = useCallback(async (sid: string | null = sessionIdRef.current, runId?: number) => {
+    clearTerminalReconcileTimer();
     // Bail out before loadSession too: a stale finish for a previous run
     // must not overwrite the messages of the run currently streaming.
     if (runId !== undefined && promptRunIdRef.current !== runId) return;
@@ -1671,7 +1682,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       dispatch({ type: "end" });
       onAgentEnd?.();
     }
-  }, [loadSession, onAgentEnd, refreshSubagentHistory, resetSubagentActivityState]);
+  }, [clearTerminalReconcileTimer, loadSession, onAgentEnd, refreshSubagentHistory, resetSubagentActivityState]);
 
   const waitForPromptSettlement = useCallback(async (sid: string, runId?: number) => {
     await delay(PROMPT_SETTLE_INITIAL_DELAY_MS);
@@ -1910,10 +1921,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           interruptReplyPendingRef.current = false;
           break;
         }
+        clearTerminalReconcileTimer();
         // A late agent_end can arrive over SSE after reconcileAgentState
         // already finished this run — don't re-trigger completion.
         if (!agentRunningRef.current) break;
-        // Capture sid + runId BEFORE clearing: the terminal reload below is
         // async, and a next prompt (or session switch) that starts while it is
         // in flight must not be overwritten by this finished run's snapshot.
         const endedSid = sessionIdRef.current;
@@ -2089,6 +2100,24 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           // surface it as live advisor activity for the composer thunder icon.
           if ((completed as CustomMessage).customType === "advisor") setAdvisorActiveAt(Date.now());
           setMessages((prev) => [...prev, normalizeToolCalls(completed)]);
+        }
+        if (completed?.role === "assistant") {
+          clearTerminalReconcileTimer();
+          const targetSid = sessionIdRef.current;
+          const targetRunId = promptRunIdRef.current;
+          if (targetSid) {
+            terminalReconcileTimerRef.current = setTimeout(() => {
+              terminalReconcileTimerRef.current = null;
+              if (
+                hookAliveRef.current &&
+                agentRunningRef.current &&
+                sessionIdRef.current === targetSid &&
+                promptRunIdRef.current === targetRunId
+              ) {
+                void reconcileAgentState(targetSid);
+              }
+            }, 1000);
+          }
         }
         dispatch({ type: "reset" });
         setAgentPhase({ kind: "waiting_model" });
@@ -2281,7 +2310,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         handleExtensionUiRequest(event as unknown as IncomingExtensionUiRequest);
         break;
     }
-  }, [addNotice, consumeQueuedMessage, finishPromptWithoutStream, handleExtensionUiRequest, handleHostToolCall, handleHostUriRequest, loadSession, mergeSubagents, onAgentEnd, reconcileAgentState, resetSubagentActivityState, applyAuthoritativeModel, beginAuthoritativeModelSync]);
+  }, [addNotice, clearTerminalReconcileTimer, consumeQueuedMessage, finishPromptWithoutStream, handleExtensionUiRequest, handleHostToolCall, handleHostUriRequest, loadSession, mergeSubagents, onAgentEnd, reconcileAgentState, resetSubagentActivityState, applyAuthoritativeModel, beginAuthoritativeModelSync]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]): Promise<boolean> => {
@@ -2300,6 +2329,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
 
     const promptRunId = promptRunIdRef.current + 1;
+    clearTerminalReconcileTimer();
 
     const { userMsg, piImages } = buildOutgoingPrompt(message, images);
     setMessages((prev) => [...prev, userMsg]);
@@ -2391,7 +2421,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       dispatch({ type: "end" });
       return false;
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, opts.chatInputRef, refreshSubagentRoster, registerHostTools, registerHostUriSchemes]);
+  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, opts.chatInputRef, refreshSubagentRoster, registerHostTools, registerHostUriSchemes, clearTerminalReconcileTimer]);
 
   /** Abort the running agent and send the message as a fresh prompt
    * (abort_and_prompt). Only valid mid-run; the old turn's agent_end is
@@ -3070,6 +3100,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       });
     }
     return () => {
+      clearTerminalReconcileTimer();
       bashRecoveryIdRef.current += 1;
       eventCoalescerRef.current?.reset();
       eventSourceRef.current?.close();

--- a/lib/api-contract.test.mjs
+++ b/lib/api-contract.test.mjs
@@ -57,11 +57,19 @@ test("worktree discovery filters prunable entries and identifies the main checko
   assert.match(source, /"worktree", "list", "--porcelain"/);
 });
 
-test("OMP update route permits check and restart actions", async () => {
+test("OMP update route permits check and restart actions with force support", async () => {
   const route = await readFile(new URL("../app/api/omp-update/route.ts", import.meta.url), "utf8");
+  const settings = await readFile(new URL("../components/SettingsConfig.tsx", import.meta.url), "utf8");
+  const appShell = await readFile(new URL("../components/AppShell.tsx", import.meta.url), "utf8");
+
   assert.match(route, /body\.action === "check"/);
+  assert.match(route, /checkOmpUpdate\(body\.force === true\)/);
   assert.match(route, /body\.action === "restart"/);
   assert.match(route, /restartAllRpcSessions/);
+
+  // Settings manual refresh passes force: true; AppShell mount check uses default
+  assert.match(settings, /fetch\("\/api\/omp-update"[\s\S]*?action:\s*"check",\s*force:\s*true/);
+  assert.match(appShell, /fetch\("\/api\/omp-update"[\s\S]*?action:\s*"check"/);
 });
 
 test("settings groups runtime preferences and resource managers behind tabs", async () => {

--- a/lib/api-contract.test.mjs
+++ b/lib/api-contract.test.mjs
@@ -67,9 +67,12 @@ test("OMP update route permits check and restart actions with force support", as
   assert.match(route, /body\.action === "restart"/);
   assert.match(route, /restartAllRpcSessions/);
 
-  // Settings manual refresh passes force: true; AppShell mount check uses default
-  assert.match(settings, /fetch\("\/api\/omp-update"[\s\S]*?action:\s*"check",\s*force:\s*true/);
+  // Settings manual refresh passes force: true; auto check uses cached default
+  assert.match(settings, /checkForUpdate\(true\)/);
+  assert.match(settings, /force:\s*true/);
+  assert.match(settings, /force = false/);
   assert.match(appShell, /fetch\("\/api\/omp-update"[\s\S]*?action:\s*"check"/);
+  assert.doesNotMatch(appShell, /force:\s*true/);
 });
 
 test("settings groups runtime preferences and resource managers behind tabs", async () => {

--- a/lib/omp/rpc-process-runtime.test.mjs
+++ b/lib/omp/rpc-process-runtime.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { RpcProcess } = jiti("./rpc-process.ts");
+const { RpcProcess, RpcCommandTimeoutError } = jiti("./rpc-process.ts");
 const { encodeRpcFrames } = jiti("./rpc-frame.ts");
 
 function makeTransport() {
@@ -118,4 +118,39 @@ test("RpcProcess reassembles v2 events and rejects pending commands when the chi
   const pending = proc.sendCommand({ type: "never_returns" });
   transport.child.emit("exit", 7, null);
   await assert.rejects(pending, /omp exited/);
+});
+
+test("RpcProcess times out commands with RpcCommandTimeoutError and ignores late responses", async () => {
+  const transport = makeTransport();
+  transport.onCommand = (command) => {
+    if (command.type === "negotiate_protocol") {
+      transport.send({ type: "response", id: command.id, command: command.type, success: true, data: { protocolVersion: 2 } });
+    }
+  };
+  const proc = startProcess(transport);
+  const ready = await proc.waitReady();
+  await proc.negotiateProtocol(ready);
+
+  const frameEvents = [];
+  proc.onFrame((frame) => frameEvents.push(frame));
+
+  const pending = proc.sendCommand({ type: "slow_command" }, 20);
+  await assert.rejects(
+    pending,
+    (err) => {
+      assert.ok(err instanceof RpcCommandTimeoutError || err.name === "RpcCommandTimeoutError");
+      assert.equal(err.command, "slow_command");
+      assert.equal(err.timeoutMs, 20);
+      return true;
+    },
+  );
+
+  // Verify late response is routed to frame listener and does not re-settle or throw
+  const slowCommand = transport.commands.find((c) => c.type === "slow_command");
+  assert.ok(slowCommand);
+  transport.send({ type: "response", id: slowCommand.id, command: "slow_command", success: true, data: "late" });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.ok(frameEvents.some((f) => f.type === "response" && f.command === "slow_command"));
+  await proc.dispose(0);
 });

--- a/lib/omp/rpc-process.ts
+++ b/lib/omp/rpc-process.ts
@@ -36,6 +36,17 @@ export class RpcCommandError extends Error {
     this.code = code;
   }
 }
+export class RpcCommandTimeoutError extends Error {
+  readonly command: string;
+  readonly timeoutMs: number;
+
+  constructor(command: string, timeoutMs: number, message?: string) {
+    super(message ?? `RPC command ${command} timed out after ${timeoutMs}ms`);
+    this.name = "RpcCommandTimeoutError";
+    this.command = command;
+    this.timeoutMs = timeoutMs;
+  }
+}
 
 interface PendingCommand {
   command: string;
@@ -248,7 +259,7 @@ export class RpcProcess {
           // not spuriously reject a different command.
           if (this.pending.get(id) === entry) {
             this.pending.delete(id);
-            reject(new Error(`RPC command ${command.type} timed out after ${timeoutMs}ms`));
+            reject(new RpcCommandTimeoutError(command.type, timeoutMs));
           }
         }, timeoutMs);
         // A pending command timer must never keep the event loop alive on its own

--- a/lib/omp/updates.test.mjs
+++ b/lib/omp/updates.test.mjs
@@ -3,8 +3,7 @@ import test from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { parseOmpUpdateStatus } = jiti("./updates.ts");
-
+const { parseOmpUpdateStatus, createCachedOmpUpdateCheck, OMP_UPDATE_CHECK_TTL_MS } = jiti("./updates.ts");
 test("parses OMP update availability without assuming an update exists", () => {
   assert.deepEqual(parseOmpUpdateStatus("Current version: 17.2.11\nNew version available: 17.2.12"), {
     currentVersion: "17.2.11",
@@ -18,4 +17,80 @@ test("parses OMP update availability without assuming an update exists", () => {
     updateAvailable: false,
     updateCommand: "omp update",
   });
+});
+
+test("createCachedOmpUpdateCheck deduplicates concurrent calls and caches results within TTL", async () => {
+  let runCalls = 0;
+  let currentTime = 1_000_000;
+
+  const fakeRun = async () => {
+    runCalls += 1;
+    await new Promise((resolve) => setImmediate(resolve));
+    return "Current version: 17.2.11\nNew version available: 17.2.12";
+  };
+
+  const checker = createCachedOmpUpdateCheck(fakeRun, () => currentTime);
+
+  // 1. Concurrent calls share one promise
+  const [res1, res2, res3] = await Promise.all([checker(), checker(), checker()]);
+  assert.equal(runCalls, 1, "Concurrent checks must only invoke run once");
+  assert.equal(res1.availableVersion, "17.2.12");
+  assert.equal(res2.availableVersion, "17.2.12");
+  assert.equal(res3.availableVersion, "17.2.12");
+
+  // 2. Cached within TTL
+  currentTime += OMP_UPDATE_CHECK_TTL_MS - 1000;
+  const resCached = await checker();
+  assert.equal(runCalls, 1, "Must hit cache before TTL expiration");
+  assert.equal(resCached.availableVersion, "17.2.12");
+
+  // 3. TTL expiration causes new run
+  currentTime += 2000;
+  const resAfterTtl = await checker();
+  assert.equal(runCalls, 2, "Must run check again after TTL expires");
+  assert.equal(resAfterTtl.availableVersion, "17.2.12");
+
+  // 4. Force bypasses completed cache
+  const resForced = await checker(true);
+  assert.equal(runCalls, 3, "force=true must bypass completed cache");
+  assert.equal(resForced.availableVersion, "17.2.12");
+});
+
+test("createCachedOmpUpdateCheck reuses in-flight promise even when force is passed", async () => {
+  let runCalls = 0;
+  let resolveRun;
+  const fakeRun = () => {
+    runCalls += 1;
+    return new Promise((resolve) => { resolveRun = resolve; });
+  };
+
+  const checker = createCachedOmpUpdateCheck(fakeRun);
+  const firstPromise = checker(false);
+  const secondPromise = checker(true); // force while first is still in flight
+
+  assert.equal(runCalls, 1, "In-flight check must be reused even when force is true");
+  resolveRun("Current version: 17.2.11\nOMP is up to date");
+  const [res1, res2] = await Promise.all([firstPromise, secondPromise]);
+  assert.equal(res1.updateAvailable, false);
+  assert.equal(res2.updateAvailable, false);
+});
+
+test("createCachedOmpUpdateCheck does not cache failures and allows retry", async () => {
+  let runCalls = 0;
+  let shouldFail = true;
+  const fakeRun = async () => {
+    runCalls += 1;
+    if (shouldFail) throw new Error("Network error");
+    return "Current version: 17.2.11\nNew version available: 17.2.13";
+  };
+
+  const checker = createCachedOmpUpdateCheck(fakeRun);
+
+  await assert.rejects(checker(), /Network error/);
+  assert.equal(runCalls, 1);
+
+  shouldFail = false;
+  const resRetry = await checker();
+  assert.equal(runCalls, 2, "Must retry after prior failure");
+  assert.equal(resRetry.availableVersion, "17.2.13");
 });

--- a/lib/omp/updates.ts
+++ b/lib/omp/updates.ts
@@ -8,12 +8,15 @@ export interface OmpUpdateStatus {
   updateCommand: string;
 }
 
-function runOmpUpdate(args: string[]): Promise<string> {
+export const OMP_UPDATE_CHECK_TIMEOUT_MS = 15_000;
+export const OMP_UPDATE_CHECK_TTL_MS = 60 * 60 * 1000;
+
+export function runOmpUpdate(args: string[], timeoutMs = OMP_UPDATE_CHECK_TIMEOUT_MS): Promise<string> {
   const bin = resolveOmpBin();
   if (!bin) return Promise.reject(new Error("omp binary not found. Install oh-my-pi or set OMP_WEB_OMP_BIN."));
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   execFile(bin, ["update", ...args], {
-    timeout: 300_000,
+    timeout: timeoutMs,
     maxBuffer: 1024 * 1024,
     env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
     windowsHide: true,
@@ -35,7 +38,41 @@ export function parseOmpUpdateStatus(output: string): OmpUpdateStatus {
   };
 }
 
-export async function checkOmpUpdate(): Promise<OmpUpdateStatus> {
-  return parseOmpUpdateStatus(await runOmpUpdate(["--check"]));
+export function createCachedOmpUpdateCheck(
+  run: () => Promise<string> = () => runOmpUpdate(["--check"]),
+  now: () => number = () => Date.now(),
+) {
+  let cached: { checkedAt: number; status: OmpUpdateStatus } | null = null;
+  let inFlight: Promise<OmpUpdateStatus> | null = null;
+
+  return async (force = false): Promise<OmpUpdateStatus> => {
+    const currentTime = now();
+    if (!force && cached && currentTime - cached.checkedAt < OMP_UPDATE_CHECK_TTL_MS) {
+      return cached.status;
+    }
+
+    if (inFlight) {
+      return inFlight;
+    }
+
+    inFlight = (async () => {
+      try {
+        const output = await run();
+        const status = parseOmpUpdateStatus(output);
+        cached = { checkedAt: now(), status };
+        return status;
+      } finally {
+        inFlight = null;
+      }
+    })();
+
+    return inFlight;
+  };
+}
+
+const defaultCachedOmpUpdateCheck = createCachedOmpUpdateCheck();
+
+export async function checkOmpUpdate(force = false): Promise<OmpUpdateStatus> {
+  return defaultCachedOmpUpdateCheck(force);
 }
 

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -203,3 +203,175 @@ test("resolveSpawnCwd uses the recorded directory when it exists, falls back oth
   assert.equal(resolveSpawnCwdResult(undefined).fellBack, true);
   assert.equal(resolveSpawnCwd(undefined), process.cwd());
 });
+
+test("missing terminal agent_end clears isPromptRunning on raw idle get_state", async () => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper } = jiti("./rpc-manager.ts");
+
+  let frameListener = null;
+  const fakeProc = {
+    isAlive: true,
+    onFrame(listener) {
+      frameListener = listener;
+      return () => { frameListener = null; };
+    },
+    sendCommand: async (command) => {
+      if (command.type === "prompt") return { agentInvoked: true };
+      if (command.type === "get_state") {
+        return {
+          sessionId: "test-session-1",
+          sessionFile: "/tmp/session.jsonl",
+          isStreaming: false,
+          isCompacting: false,
+        };
+      }
+      return {};
+    },
+    sendFrame: () => {},
+    dispose: async () => {},
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.start();
+
+  await wrapper.send({ type: "prompt", message: "Hello" });
+  frameListener({ type: "agent_start" });
+  assert.equal(wrapper.isRunning(), true);
+
+  // Missing agent_end frame — get_state reports raw idle
+  const state = await wrapper.send({ type: "get_state" });
+  assert.equal(state.isPromptRunning, false);
+  assert.equal(wrapper.isRunning(), false);
+  await wrapper.destroyAndWait();
+});
+
+test("prompt ack pending does not let raw idle get_state clear promptRunning", async () => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper } = jiti("./rpc-manager.ts");
+
+  let resolvePromptAck;
+  const fakeProc = {
+    isAlive: true,
+    onFrame: () => () => {},
+    sendCommand: async (command) => {
+      if (command.type === "prompt") {
+        return new Promise((resolve) => { resolvePromptAck = resolve; });
+      }
+      if (command.type === "get_state") {
+        return {
+          sessionId: "test-session-2",
+          isStreaming: false,
+          isCompacting: false,
+        };
+      }
+      return {};
+    },
+    sendFrame: () => {},
+    dispose: async () => {},
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.start();
+
+  const promptPromise = wrapper.send({ type: "prompt", message: "Hello" });
+  assert.equal(wrapper.isRunning(), true);
+
+  // While prompt ack is still pending, get_state must not clear isPromptRunning
+  const state = await wrapper.send({ type: "get_state" });
+  assert.equal(state.isPromptRunning, true);
+  assert.equal(wrapper.isRunning(), true);
+
+  resolvePromptAck({ agentInvoked: true });
+  await promptPromise;
+  await wrapper.destroyAndWait();
+});
+
+test("isTerminal:false respects 2-second grace period before raw idle can clear prompt", async () => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper } = jiti("./rpc-manager.ts");
+
+  let frameListener = null;
+  const fakeProc = {
+    isAlive: true,
+    onFrame(listener) {
+      frameListener = listener;
+      return () => { frameListener = null; };
+    },
+    sendCommand: async (command) => {
+      if (command.type === "prompt") return { agentInvoked: true };
+      if (command.type === "get_state") {
+        return {
+          sessionId: "test-session-3",
+          isStreaming: false,
+          isCompacting: false,
+        };
+      }
+      return {};
+    },
+    sendFrame: () => {},
+    dispose: async () => {},
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.start();
+
+  await wrapper.send({ type: "prompt", message: "Hello" });
+  frameListener({ type: "agent_start" });
+  frameListener({ type: "agent_end", isTerminal: false });
+
+  // Within the grace period, raw idle does not clear promptRunning
+  const stateDuringGrace = await wrapper.send({ type: "get_state" });
+  assert.equal(stateDuringGrace.isPromptRunning, true);
+
+  // After grace period expires, raw idle clears promptRunning
+  const realNow = Date.now;
+  try {
+    Date.now = () => realNow() + 3000;
+    const stateAfterGrace = await wrapper.send({ type: "get_state" });
+    assert.equal(stateAfterGrace.isPromptRunning, false);
+    assert.equal(wrapper.isRunning(), false);
+  } finally {
+    Date.now = realNow;
+  }
+  await wrapper.destroyAndWait();
+});
+
+test("get_state timeout recycles wrapper and produces session_unresponsive WebRpcError", async () => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper, WebRpcError } = jiti("./rpc-manager.ts");
+  const { RpcCommandTimeoutError } = jiti("./omp/rpc-process.ts");
+
+  let disposed = false;
+  const fakeProc = {
+    isAlive: true,
+    onFrame: () => () => {},
+    sendCommand: async (command, timeoutMs) => {
+      if (command.type === "get_state") {
+        assert.equal(timeoutMs, 5000);
+        throw new RpcCommandTimeoutError("get_state", 5000);
+      }
+      return {};
+    },
+    sendFrame: () => {},
+    dispose: async () => { disposed = true; },
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.start();
+
+  await assert.rejects(
+    wrapper.send({ type: "get_state" }),
+    (err) => {
+      assert.ok(err instanceof WebRpcError || err.name === "WebRpcError");
+      assert.equal(err.code, "session_unresponsive");
+      return true;
+    },
+  );
+
+  assert.equal(disposed, true);
+  assert.equal(wrapper.isAlive(), false);
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1198,6 +1198,10 @@ export class AgentSessionWrapper {
     }
     this.unsubscribeFrames?.();
     this.clearPendingUiRequests();
+    this.promptDispatchPendingCount = 0;
+    this.awaitingAgentStart = false;
+    this.awaitingAgentStartDeadline = 0;
+    this.continuationGraceUntil = 0;
     if (this.mcpListWaiter) {
       clearTimeout(this.mcpListWaiter.timer);
       this.mcpListWaiter.reject(new Error("Session was closed while loading MCP servers"));
@@ -1209,9 +1213,9 @@ export class AgentSessionWrapper {
     this.hostToolNames.clear();
     this.pendingHostUris.clear();
     this.hostUriSchemes.clear();
-    this.onDestroyCallback?.();
     notifyRunningChange();
     await disposed;
+    this.onDestroyCallback?.();
   }
 }
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs";
 import { homedir } from "os";
 import { validateAgentImages } from "./image-attachments";
 import { invalidateModelsCache } from "./models-cache";
-import { RpcCommandError, RpcProcess, type RpcFrame } from "./omp/rpc-process";
+import { RpcCommandError, RpcCommandTimeoutError, RpcProcess, type RpcFrame } from "./omp/rpc-process";
 import { readNativeSettings } from "./omp/settings-config";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import { PRESET_FULL } from "./tool-presets";
@@ -38,7 +38,8 @@ interface CompactionResultLike {
 const IDLE_DESTROY_MS = 10 * 60 * 1000;
 const READY_TIMEOUT_MS = 120_000;
 const MCP_LIST_TIMEOUT_MS = 15_000;
-
+const GET_STATE_TIMEOUT_MS = 5_000;
+const NON_TERMINAL_CONTINUATION_GRACE_MS = 2_000;
 const RESTARTING_MESSAGE = "This session is restarting — retry in a moment.";
 const BASH_EXCLUDE_MESSAGE =
   "omp cannot run a shell command with its output excluded from the model context (`!!`): the RPC bash command has no exclusion option, so the output would silently enter the context anyway. Run it with a single `!` to share the output with the model, or use a terminal outside omp web.";
@@ -206,6 +207,8 @@ export class AgentSessionWrapper {
   private extensionStatuses = new Map<string, string>();
   private extensionWidgets = new Map<string, ExtensionWidgetItem>();
   private promptRunning = false;
+  private promptDispatchPending = false;
+  private continuationGraceUntil = 0;
   private bashRunning = false;
   private streaming = false;
   private compacting = false;
@@ -349,7 +352,9 @@ export class AgentSessionWrapper {
         break;
       }
       case "agent_start":
+        this.promptRunning = true;
         this.streaming = true;
+        this.continuationGraceUntil = 0;
         // The session file can appear just after the prompt acknowledgement.
         // Invalidate and signal the sidebar now rather than waiting for the
         // agent's first reply or terminal event.
@@ -369,7 +374,10 @@ export class AgentSessionWrapper {
         if (event.isTerminal !== false) {
           this.streaming = false;
           this.promptRunning = false;
+          this.continuationGraceUntil = 0;
           invalidateSessionListCache();
+        } else {
+          this.continuationGraceUntil = Date.now() + NON_TERMINAL_CONTINUATION_GRACE_MS;
         }
         break;
       case "prompt_result":
@@ -739,6 +747,8 @@ export class AgentSessionWrapper {
   }
 
   private buildWebState(state: RpcSessionState): WebSessionState {
+    const wasRunning = this.isRunning();
+
     // Reconcile process-side flags with authoritative child state.
     this.streaming = state.isStreaming;
     this.compacting = state.isCompacting;
@@ -746,6 +756,19 @@ export class AgentSessionWrapper {
     if (state.sessionId) {
       this._sessionId = state.sessionId;
       this._sessionFile = state.sessionFile ?? this._sessionFile;
+    }
+
+    if (
+      state.isStreaming === false &&
+      state.isCompacting === false &&
+      !this.promptDispatchPending &&
+      Date.now() >= this.continuationGraceUntil
+    ) {
+      this.promptRunning = false;
+    }
+
+    if (wasRunning && !this.isRunning()) {
+      notifyRunningChange();
     }
     return {
       sessionId: state.sessionId,
@@ -820,10 +843,11 @@ export class AgentSessionWrapper {
       this.extensionWidgets.clear();
       this.clearPendingUiRequests();
       this.promptRunning = false;
+      this.promptDispatchPending = false;
+      this.continuationGraceUntil = 0;
       this.bashRunning = false;
       this.streaming = false;
       this.compacting = false;
-
       const proc = new RpcProcess({
         cwd: this.cwd,
         extraArgs: buildSessionSpawnArgs(resumable ? sessionFile : ""),
@@ -879,6 +903,8 @@ export class AgentSessionWrapper {
         const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
         if (!streamingBehavior) {
           this.promptRunning = true;
+          this.promptDispatchPending = true;
+          this.continuationGraceUntil = 0;
           notifyRunningChange();
         }
         try {
@@ -901,6 +927,10 @@ export class AgentSessionWrapper {
           this.promptRunning = false;
           notifyRunningChange();
           throw error;
+        } finally {
+          if (!streamingBehavior) {
+            this.promptDispatchPending = false;
+          }
         }
         return null;
       }
@@ -926,8 +956,16 @@ export class AgentSessionWrapper {
         return null;
 
       case "get_state": {
-        const state = await this.proc.sendCommand<RpcSessionState>({ type: "get_state" });
-        return this.buildWebState(state);
+        try {
+          const state = await this.proc.sendCommand<RpcSessionState>({ type: "get_state" }, GET_STATE_TIMEOUT_MS);
+          return this.buildWebState(state);
+        } catch (error) {
+          if (error instanceof RpcCommandTimeoutError || (error instanceof Error && error.name === "RpcCommandTimeoutError")) {
+            await this.destroyAndWait();
+            throw new WebRpcError("The OMP session stopped responding and was reset.", "session_unresponsive");
+          }
+          throw error;
+        }
       }
 
       case "set_model": {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -40,6 +40,7 @@ const READY_TIMEOUT_MS = 120_000;
 const MCP_LIST_TIMEOUT_MS = 15_000;
 const GET_STATE_TIMEOUT_MS = 5_000;
 const NON_TERMINAL_CONTINUATION_GRACE_MS = 2_000;
+const AWAITING_AGENT_START_TIMEOUT_MS = 10_000;
 const RESTARTING_MESSAGE = "This session is restarting — retry in a moment.";
 const BASH_EXCLUDE_MESSAGE =
   "omp cannot run a shell command with its output excluded from the model context (`!!`): the RPC bash command has no exclusion option, so the output would silently enter the context anyway. Run it with a single `!` to share the output with the model, or use a terminal outside omp web.";
@@ -207,7 +208,9 @@ export class AgentSessionWrapper {
   private extensionStatuses = new Map<string, string>();
   private extensionWidgets = new Map<string, ExtensionWidgetItem>();
   private promptRunning = false;
-  private promptDispatchPending = false;
+  private promptDispatchPendingCount = 0;
+  private awaitingAgentStart = false;
+  private awaitingAgentStartDeadline = 0;
   private continuationGraceUntil = 0;
   private bashRunning = false;
   private streaming = false;
@@ -290,7 +293,7 @@ export class AgentSessionWrapper {
     // a live subagent roster. Older omp builds may not know the command —
     // degrade silently (the UI falls back to no subagent info).
     await this.proc.sendCommand({ type: "set_subagent_subscription", level: "events" }).catch(() => {});
-    const state = await this.proc.sendCommand<RpcSessionState>({ type: "get_state" });
+    const state = await this.getStateWithTimeout();
     this.applyIdentity(state);
     // Warn when the spawn cwd differs from the session's recorded directory.
     // This happens when the recorded cwd was deleted (removed worktree, moved
@@ -354,6 +357,8 @@ export class AgentSessionWrapper {
       case "agent_start":
         this.promptRunning = true;
         this.streaming = true;
+        this.awaitingAgentStart = false;
+        this.awaitingAgentStartDeadline = 0;
         this.continuationGraceUntil = 0;
         // The session file can appear just after the prompt acknowledgement.
         // Invalidate and signal the sidebar now rather than waiting for the
@@ -374,6 +379,8 @@ export class AgentSessionWrapper {
         if (event.isTerminal !== false) {
           this.streaming = false;
           this.promptRunning = false;
+          this.awaitingAgentStart = false;
+          this.awaitingAgentStartDeadline = 0;
           this.continuationGraceUntil = 0;
           invalidateSessionListCache();
         } else {
@@ -383,6 +390,8 @@ export class AgentSessionWrapper {
       case "prompt_result":
         // Local-only prompt (builtin/extension slash command) — no agent run.
         this.promptRunning = false;
+        this.awaitingAgentStart = false;
+        this.awaitingAgentStartDeadline = 0;
         break;
       case "auto_compaction_start":
         this.compacting = true;
@@ -404,6 +413,8 @@ export class AgentSessionWrapper {
         // reuses the original command id after the immediate ack).
         if (event.success === false && event.command === "prompt") {
           this.promptRunning = false;
+          this.awaitingAgentStart = false;
+          this.awaitingAgentStartDeadline = 0;
           this.emit({ type: "prompt_error", errorMessage: (event.error as string) ?? "Prompt failed" });
           notifyRunningChange();
           return;
@@ -758,13 +769,24 @@ export class AgentSessionWrapper {
       this._sessionFile = state.sessionFile ?? this._sessionFile;
     }
 
+    const awaitingExpired = !this.awaitingAgentStart || Date.now() >= this.awaitingAgentStartDeadline;
+    const hasPendingWork =
+      this.promptDispatchPendingCount > 0 ||
+      (this.awaitingAgentStart && !awaitingExpired) ||
+      this.mcpListWaiter !== null ||
+      this.pendingUiRequests.size > 0 ||
+      this.pendingHostTools.size > 0 ||
+      this.pendingHostUris.size > 0;
+
     if (
       state.isStreaming === false &&
       state.isCompacting === false &&
-      !this.promptDispatchPending &&
+      !hasPendingWork &&
       Date.now() >= this.continuationGraceUntil
     ) {
       this.promptRunning = false;
+      this.awaitingAgentStart = false;
+      this.awaitingAgentStartDeadline = 0;
     }
 
     if (wasRunning && !this.isRunning()) {
@@ -810,11 +832,15 @@ export class AgentSessionWrapper {
     };
   }
 
+  private async getStateWithTimeout(): Promise<RpcSessionState> {
+    return this.proc.sendCommand<RpcSessionState>({ type: "get_state" }, GET_STATE_TIMEOUT_MS);
+  }
+
   /** After branch/new_session/switch_session the child is on a different
    * session file — re-read identity and re-register in the registry. */
   private async refreshIdentityAfterSessionChange(): Promise<string> {
     const oldId = this._sessionId;
-    const state = await this.proc.sendCommand<RpcSessionState>({ type: "get_state" });
+    const state = await this.getStateWithTimeout();
     this.applyIdentity(state);
     if (oldId && oldId !== this._sessionId) {
       this.onIdentityChangeCallback?.(oldId, this._sessionId);
@@ -843,7 +869,9 @@ export class AgentSessionWrapper {
       this.extensionWidgets.clear();
       this.clearPendingUiRequests();
       this.promptRunning = false;
-      this.promptDispatchPending = false;
+      this.promptDispatchPendingCount = 0;
+      this.awaitingAgentStart = false;
+      this.awaitingAgentStartDeadline = 0;
       this.continuationGraceUntil = 0;
       this.bashRunning = false;
       this.streaming = false;
@@ -863,7 +891,7 @@ export class AgentSessionWrapper {
         // The replacement process starts with subscriptions disabled; restore
         // the live roster/transcript event stream before reading its state.
         await proc.sendCommand({ type: "set_subagent_subscription", level: "events" }).catch(() => {});
-        const state = await proc.sendCommand<RpcSessionState>({ type: "get_state" });
+        const state = await proc.sendCommand<RpcSessionState>({ type: "get_state" }, GET_STATE_TIMEOUT_MS);
         this.applyIdentity(state);
       } catch (error) {
         // Never leave the replacement running with nobody reading its frames.
@@ -903,7 +931,9 @@ export class AgentSessionWrapper {
         const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
         if (!streamingBehavior) {
           this.promptRunning = true;
-          this.promptDispatchPending = true;
+          this.promptDispatchPendingCount += 1;
+          this.awaitingAgentStart = false;
+          this.awaitingAgentStartDeadline = 0;
           this.continuationGraceUntil = 0;
           notifyRunningChange();
         }
@@ -920,16 +950,25 @@ export class AgentSessionWrapper {
           // in the ack itself — no prompt_result frame follows.
           if (ack?.agentInvoked === false && !streamingBehavior) {
             this.promptRunning = false;
+            this.awaitingAgentStart = false;
+            this.awaitingAgentStartDeadline = 0;
             this.emit({ type: "prompt_result", agentInvoked: false });
             notifyRunningChange();
+          } else if (!streamingBehavior && ack?.agentInvoked !== false) {
+            // OMP acked but agent hasn't started yet — keep promptRunning alive
+            // until agent_start arrives (or a timeout expires).
+            this.awaitingAgentStart = true;
+            this.awaitingAgentStartDeadline = Date.now() + AWAITING_AGENT_START_TIMEOUT_MS;
           }
         } catch (error) {
           this.promptRunning = false;
+          this.awaitingAgentStart = false;
+          this.awaitingAgentStartDeadline = 0;
           notifyRunningChange();
           throw error;
         } finally {
           if (!streamingBehavior) {
-            this.promptDispatchPending = false;
+            this.promptDispatchPendingCount = Math.max(0, this.promptDispatchPendingCount - 1);
           }
         }
         return null;

--- a/lib/sse-lifecycle.test.mjs
+++ b/lib/sse-lifecycle.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { createJiti } from "jiti";
+const jiti = createJiti(import.meta.url, {
+  alias: {
+    "@/": new URL("../", import.meta.url).pathname,
+  },
+});
+const singleSessionRoute = await jiti.import("../app/api/agent/[id]/events/route.ts");
+const runningRoute = await jiti.import("../app/api/agent/running/events/route.ts");
+
+test("single-session SSE route cleans up and unsubscribes exactly once on abort / cancel", async () => {
+  if (!globalThis.__ompSessions) globalThis.__ompSessions = new Map();
+
+  let unsubscribeCount = 0;
+
+  const mockSession = {
+    isAlive: () => true,
+    onEvent: () => {
+      return () => {
+        unsubscribeCount += 1;
+      };
+    },
+  };
+
+  globalThis.__ompSessions.set("test-sess-lifecycle", mockSession);
+
+  try {
+    const ac = new AbortController();
+    const req = new Request("http://localhost/api/agent/test-sess-lifecycle/events", {
+      signal: ac.signal,
+    });
+
+    const res = await singleSessionRoute.GET(req, {
+      params: Promise.resolve({ id: "test-sess-lifecycle" }),
+    });
+
+    assert.equal(res.status, 200);
+    assert.ok(res.body);
+
+    const reader = res.body.getReader();
+    const firstChunk = await reader.read();
+    assert.equal(firstChunk.done, false);
+    const text = new TextDecoder().decode(firstChunk.value);
+    assert.ok(text.includes('"type":"connected"'));
+
+    // Abort controller
+    ac.abort();
+    // And cancel reader (as browser would on navigation/close)
+    await reader.cancel();
+
+    assert.equal(unsubscribeCount, 1, "RPC event listener must be unsubscribed exactly once");
+  } finally {
+    globalThis.__ompSessions.delete("test-sess-lifecycle");
+  }
+});
+
+test("running-sessions SSE route returns listener count to baseline after abort / cancel", async () => {
+  if (!globalThis.__ompRunningListeners) globalThis.__ompRunningListeners = new Set();
+  const baselineListeners = globalThis.__ompRunningListeners.size;
+
+  const ac = new AbortController();
+  const req = new Request("http://localhost/api/agent/running/events", {
+    signal: ac.signal,
+  });
+
+  const res = await runningRoute.GET(req);
+  assert.equal(res.status, 200);
+  assert.ok(res.body);
+
+  const reader = res.body.getReader();
+  const firstChunk = await reader.read();
+  assert.equal(firstChunk.done, false);
+  const text = new TextDecoder().decode(firstChunk.value);
+  assert.ok(text.includes('"type":"running"'));
+
+  // Inside the stream, listener was registered
+  assert.equal(globalThis.__ompRunningListeners.size, baselineListeners + 1);
+
+  // Abort and cancel
+  ac.abort();
+  await reader.cancel();
+
+  assert.equal(
+    globalThis.__ompRunningListeners.size,
+    baselineListeners,
+    "Running session listeners must return to baseline without leaks",
+  );
+});
+
+test("source contract: SSE routes invoke unified cleanup on enqueue errors and separate closed from cleaned", async () => {
+  const singleSrc = await readFile(new URL("../app/api/agent/[id]/events/route.ts", import.meta.url), "utf8");
+  const runningSrc = await readFile(new URL("../app/api/agent/running/events/route.ts", import.meta.url), "utf8");
+
+  // Single-session SSE contract
+  assert.ok(singleSrc.includes("let closed = false;"), "must track closed state");
+  assert.ok(singleSrc.includes("let cleaned = false;"), "must track cleaned state");
+  assert.ok(singleSrc.includes("if (cleaned) return;"), "cleanup guard must check cleaned, not closed");
+  assert.ok(!singleSrc.includes("catch {\n          closed = true;\n        }"), "write catch must not merely set closed=true without cleanup");
+
+  // Running SSE contract
+  assert.ok(runningSrc.includes("let closed = false;"), "must track closed state");
+  assert.ok(runningSrc.includes("let cleaned = false;"), "must track cleaned state");
+  assert.ok(runningSrc.includes("if (cleaned) return;"), "cleanup guard must check cleaned, not closed");
+  assert.ok(runningSrc.includes("const encoder = new TextEncoder();"), "must reuse TextEncoder instance");
+});

--- a/lib/tool-preset-preference.test.mjs
+++ b/lib/tool-preset-preference.test.mjs
@@ -4,6 +4,7 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
 const { getPreferredToolPreset, setPreferredToolPreset } = await jiti.import("./tool-preset-preference.ts");
+const { getToolNamesForPreset } = await jiti.import("./tool-presets.ts");
 
 function createStorage(values = {}) {
   const entries = new Map(Object.entries(values));
@@ -13,10 +14,19 @@ function createStorage(values = {}) {
   };
 }
 
-test("persists only known tool preset values", () => {
+test("defaults to the full OMP toolset and persists explicit choices", () => {
   const storage = createStorage({ "omp-web:tool-preset": "unknown" });
+  assert.equal(getPreferredToolPreset(storage), "full");
+
+  setPreferredToolPreset("default", storage);
   assert.equal(getPreferredToolPreset(storage), "default");
 
   setPreferredToolPreset("full", storage);
   assert.equal(getPreferredToolPreset(storage), "full");
+});
+
+test("full preset leaves OMP's native toolset unrestricted", () => {
+  assert.equal(getToolNamesForPreset("full"), undefined);
+  assert.deepEqual(getToolNamesForPreset("default"), ["read", "bash", "edit", "write"]);
+  assert.deepEqual(getToolNamesForPreset("none"), []);
 });

--- a/lib/tool-preset-preference.ts
+++ b/lib/tool-preset-preference.ts
@@ -17,12 +17,12 @@ function browserStorage(): StorageLike | null {
 }
 
 export function getPreferredToolPreset(storage: StorageLike | null = browserStorage()): ToolPreset {
-  if (!storage) return "default";
+  if (!storage) return "full";
   try {
     const value = storage.getItem(STORAGE_KEY);
-    return isToolPreset(value) ? value : "default";
+    return isToolPreset(value) ? value : "full";
   } catch {
-    return "default";
+    return "full";
   }
 }
 

--- a/lib/tool-presets.ts
+++ b/lib/tool-presets.ts
@@ -31,8 +31,8 @@ export function getPresetFromTools(tools: ToolEntry[]): ToolPreset {
   return "default";
 }
 
-export function getToolNamesForPreset(preset: ToolPreset): string[] {
+export function getToolNamesForPreset(preset: ToolPreset): string[] | undefined {
   if (preset === "none") return [...PRESET_NONE];
-  if (preset === "full") return [...PRESET_FULL];
+  if (preset === "full") return undefined;
   return [...PRESET_DEFAULT];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kahme247/ompweb",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Web UI for the oh-my-pi (omp) coding agent",
   "homepage": "https://github.com/kahme247/ompweb#readme",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes two correlated runtime reliability issues: sessions getting stuck in "running" state after full responses are displayed, and occasional slow loading / unresponsiveness when refreshing the web UI.

### Key Changes

1. **OMP Authoritative State Alignment & Bounded Timeout Recovery (`lib/omp/rpc-process.ts`, `lib/rpc-manager.ts`)**
   - Added `RpcCommandTimeoutError` thrown by `sendCommand()` when commands exceed their configured timeout.
   - Added `GET_STATE_TIMEOUT_MS = 5_000`, `NON_TERMINAL_CONTINUATION_GRACE_MS = 2_000`, `promptDispatchPending`, and `continuationGraceUntil` to `AgentSessionWrapper`.
   - `buildWebState()` reconciles authoritative OMP idle state (`isStreaming: false`, `isCompacting: false`, `promptDispatchPending: false`, grace window expired) to converge lingering `promptRunning` to `false` and broadcasts the update via `notifyRunningChange()`.
   - `get_state` RPC timeouts trigger `destroyAndWait()` to cleanly recycle unresponsive child processes and return recoverable idle state (`session_unresponsive` -> `{ running: false, recovered: true }`) so future prompts can re-spawn naturally.

2. **Unblock Initial Render & Fast Terminal Self-Healing (`hooks/useAgentSession.ts`)**
   - `loadSession()` immediately sets `loading: false` after applying disk messages and metadata, so subsequent live-state requests no longer block the user from reading historical messages.
   - Introduced `terminalReconcileTimerRef`: 1s after receiving an assistant `message_end`, active runs trigger `reconcileAgentState()`. If a terminal `agent_end` was dropped, the session immediately converges to idle rather than waiting for the 15s periodic poll.

3. **SSE Resource Lifecycle & Idempotent Cleanup (`app/api/agent/[id]/events/route.ts`, `app/api/agent/running/events/route.ts`)**
   - Separated `closed` (write disabled) from `cleaned` (resources freed) state.
   - Idempotent `cleanup()` clears heartbeats, removes abort listeners, unbinds RPC / session watcher subscribers, and closes streams, ensuring write errors or client aborts never leak background listeners.

4. **OMP Update Check Caching & Deduplication (`lib/omp/updates.ts`, `app/api/omp-update/route.ts`, `components/SettingsConfig.tsx`)**
   - Added `createCachedOmpUpdateCheck()` with 1-hour TTL and in-flight promise deduplication.
   - Tightened `omp update --check` command timeout to 15s.
   - Added `force: true` support for manual refresh in Settings.

### Verification

- Unit & contract tests:
  - `lib/omp/rpc-process-runtime.test.mjs` (timeout error types, pending command removal)
  - `lib/rpc-manager.test.mjs` (idle convergence on missed `agent_end`, pending ack guards, grace window protection, timeout recovery)
  - `lib/sse-lifecycle.test.mjs` (single-session and running-session cleanup idempotency and listener baseline recovery)
  - `lib/omp/updates.test.mjs` & `lib/api-contract.test.mjs` (dedup, TTL, force, retry)
  - Full suite `npm test` (415 tests passing)
- Typecheck & Lint: `tsc --noEmit` and `npm run lint` pass with 0 errors/warnings.
- E2E & Staging: Verified on live candidate instance and deployed service with real model turns, in-flight reload resilience, and multi-tab stress tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when sessions become unresponsive, accurately reporting them as stopped.
  * Fixed session state synchronization after assistant responses and terminal events.
  * Improved cleanup of live event streams when connections close, abort, or encounter errors.
  * Added clearer handling for RPC command timeouts.

* **Improvements**
  * Manual update checks can now be forced.
  * Update checks are cached and deduplicated, with faster timeout handling and retry support.
  * Added coverage for session recovery, stream cleanup, update checks, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two correlated runtime reliability issues: sessions getting stuck in "running" state after full responses were displayed, and slow loading or unresponsiveness when refreshing the web UI.

**Runtime reliability**

- `get_state` RPC calls now time out after 5 seconds; unresponsive child processes are recycled and report a recoverable idle state (`recovered: true`).
- Session state now reconciles against the authoritative OMP idle state, so a missed terminal `agent_end` clears `promptRunning` within 1 second of the final assistant message.
- `loadSession()` no longer waits on live state to render historical messages.

**SSE cleanup & update checks**

- SSE routes now separate `closed` (writes disabled) from `cleaned` (resources freed) so aborts and write errors never leak heartbeats or listeners.
- OMP update checks are cached for 1 hour with in-flight deduplication and a 15s timeout; the Settings manual refresh passes `force: true` to bypass the cache.

<sup>Written for commit 69e44c84c376feb05a3b543ea6e2fb91263ce98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

