### PR TITLE
fix: preserve full OMP tools in new sessions

### DIFF
--- a/lib/tool-preset-preference.test.mjs
+++ b/lib/tool-preset-preference.test.mjs
@@ -4,6 +4,7 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
 const { getPreferredToolPreset, setPreferredToolPreset } = await jiti.import("./tool-preset-preference.ts");
+const { getToolNamesForPreset } = await jiti.import("./tool-presets.ts");
 
 function createStorage(values = {}) {
   const entries = new Map(Object.entries(values));
@@ -13,10 +14,19 @@ function createStorage(values = {}) {
   };
 }
 
-test("persists only known tool preset values", () => {
+test("defaults to the full OMP toolset and persists explicit choices", () => {
   const storage = createStorage({ "omp-web:tool-preset": "unknown" });
+  assert.equal(getPreferredToolPreset(storage), "full");
+
+  setPreferredToolPreset("default", storage);
   assert.equal(getPreferredToolPreset(storage), "default");
 
   setPreferredToolPreset("full", storage);
   assert.equal(getPreferredToolPreset(storage), "full");
+});
+
+test("full preset leaves OMP's native toolset unrestricted", () => {
+  assert.equal(getToolNamesForPreset("full"), undefined);
+  assert.deepEqual(getToolNamesForPreset("default"), ["read", "bash", "edit", "write"]);
+  assert.deepEqual(getToolNamesForPreset("none"), []);
 });

--- a/lib/tool-preset-preference.ts
+++ b/lib/tool-preset-preference.ts
@@ -17,12 +17,12 @@ function browserStorage(): StorageLike | null {
 }
 
 export function getPreferredToolPreset(storage: StorageLike | null = browserStorage()): ToolPreset {
-  if (!storage) return "default";
+  if (!storage) return "full";
   try {
     const value = storage.getItem(STORAGE_KEY);
-    return isToolPreset(value) ? value : "default";
+    return isToolPreset(value) ? value : "full";
   } catch {
-    return "default";
+    return "full";
   }
 }
 

--- a/lib/tool-presets.ts
+++ b/lib/tool-presets.ts
@@ -31,8 +31,8 @@ export function getPresetFromTools(tools: ToolEntry[]): ToolPreset {
   return "default";
 }
 
-export function getToolNamesForPreset(preset: ToolPreset): string[] {
+export function getToolNamesForPreset(preset: ToolPreset): string[] | undefined {
   if (preset === "none") return [...PRESET_NONE];
-  if (preset === "full") return [...PRESET_FULL];
+  if (preset === "full") return undefined;
   return [...PRESET_DEFAULT];
 }


### PR DESCRIPTION
## Summary

- default fresh browser profiles to the full OMP tool preset
- omit `toolNames` for the full preset so OMP keeps its complete native toolset
- preserve explicit four-tool and no-tool choices
- cover the default and spawn-filter behavior with focused tests

## Problem

New ompweb sessions currently default to the four-tool preset (`read`, `bash`, `edit`, `write`). This unintentionally hides OMP-native tools such as `task`, `ask`, `todo`, and `lsp`. The full preset should delegate tool discovery to the installed OMP version rather than sending a restrictive static list.

## Verification

- `node --experimental-strip-types --test lib/tool-preset-preference.test.mjs`
- `npm run typecheck`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes new ompweb sessions defaulting to the four-tool preset, which unintentionally hid OMP-native tools like `task`, `ask`, `todo`, and `lsp`. New sessions now default to the full preset, which omits `toolNames` so OMP keeps its complete native toolset. Explicit four-tool and no-tool choices are unchanged.

**Behavior**
- Unknown or missing stored presets now fall back to "full" instead of "default".
- Tests cover the new default and the full preset's unrestricted native toolset.

<sup>Written for commit 205bbd3acd4941cf5664df5a7b63667976e91749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kahme247/ompweb/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated tool preset preferences to fall back to the **Full** preset when saved settings are unavailable, invalid, or cannot be read.
  - The **Full** preset now correctly represents using all available tools, while **Default** and **None** retain their intended tool selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->