### PR TITLE
fix: minimap tooltip transparency and chat text overlap

### DIFF
--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useEffect, useRef, useState, useCallback, useMemo, RefObject } from "react";
 import type { AgentMessage, AssistantMessage, TextContent } from "@/lib/types";
+import { MINIMAP_WIDTH } from "@/lib/chat-layout";
 
 interface Props {
   messages: AgentMessage[];
@@ -9,7 +10,6 @@ interface Props {
   messageRefs: RefObject<(HTMLDivElement | null)[]>;
 }
 
-const MINIMAP_WIDTH = 36;
 
 function getMessagePreview(msg: AgentMessage | Partial<AgentMessage>): string {
   if (msg.role === "user") {
@@ -70,9 +70,11 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
   const [nodes, setNodes] = useState<NodeInfo[]>([]);
   const [minimapHovered, setMinimapHovered] = useState(false);
   const [mouseYRatio, setMouseYRatio] = useState<number | null>(null);
+  const [hoveredTooltipIndex, setHoveredTooltipIndex] = useState<number | null>(null);
   const draggingRef = useRef(false);
   const dragListenersRef = useRef<{ onMove: (ev: MouseEvent) => void; onUp: () => void } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const overflowPanelRef = useRef<HTMLDivElement>(null);
   // RAF gate for mousemove so a pixel-level pointer event doesn't re-render
   // the whole minimap (every node + tooltip) on every frame.
   const mouseMoveRafRef = useRef<number | null>(null);
@@ -284,6 +286,7 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
   const TOOLTIP_HEIGHT = 22;
   const TOOLTIP_GAP = 2;
   const minimapHeightPx = containerRef.current?.clientHeight ?? 600;
+  const tooltipListOverflows = nodes.length * (TOOLTIP_HEIGHT + TOOLTIP_GAP) > minimapHeightPx;
 
   // Per-node colors and previews are pure functions of each node's message;
   // memoize so they aren't recomputed on every scroll/mousemove re-render.
@@ -291,7 +294,7 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
   const nodePreviews = useMemo(() => nodes.map((node) => getMessagePreview(node.msg)), [nodes]);
 
   const tooltipPositions = useMemo(() => {
-    if (!minimapHovered || nodes.length === 0) return [];
+    if (!minimapHovered || nodes.length === 0 || tooltipListOverflows) return [];
     // Initial positions: centered on the dot
     const positions = nodes.map((node) =>
       Math.round(node.topRatio * minimapHeightPx - TOOLTIP_HEIGHT / 2)
@@ -312,26 +315,40 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
       positions[i] = Math.max(0, Math.min(minimapHeightPx - TOOLTIP_HEIGHT, positions[i]));
     }
     return positions;
-  }, [minimapHovered, nodes, minimapHeightPx]);
+  }, [minimapHovered, nodes, minimapHeightPx, tooltipListOverflows]);
+
+  // Find the node closest to the current mouse position; direct tooltip
+  // hover takes precedence (collision-free layout shifts tooltip positions
+  // away from their node's scroll ratio, so Y-distance is wrong there).
+  const computedNearest = mouseYRatio !== null && nodes.length > 0
+    ? nodes.reduce((best, node) => {
+        return Math.abs(node.topRatio - mouseYRatio) < Math.abs(nodes[best].topRatio - mouseYRatio) ? node.index : best;
+      }, 0)
+    : null;
+  const nearestIndex = hoveredTooltipIndex ?? computedNearest;
+
+  // Auto-scroll the overflow tooltip panel to keep the minimap-driven
+  // selection visible. Skipped when the user is directly hovering over the
+  // panel (hoveredTooltipIndex !== null) to avoid fighting manual scrolling.
+  useEffect(() => {
+    if (computedNearest === null || hoveredTooltipIndex !== null) return;
+    const panel = overflowPanelRef.current;
+    if (!panel) return;
+    const row = panel.querySelector(`[data-node-index="${computedNearest}"]`) as HTMLElement | null;
+    row?.scrollIntoView({ block: "nearest" });
+  }, [computedNearest, hoveredTooltipIndex]);
 
   if (!visible) return null;
 
   const viewportBoxTop = scrollRatio * (1 - viewportRatio) * 100;
   const viewportBoxHeight = viewportRatio * 100;
 
-  // Find the node closest to the current mouse position
-  const nearestIndex = mouseYRatio !== null && nodes.length > 0
-    ? nodes.reduce((best, node) => {
-        return Math.abs(node.topRatio - mouseYRatio) < Math.abs(nodes[best].topRatio - mouseYRatio) ? node.index : best;
-      }, 0)
-    : null;
-
   return (
     <div
       ref={containerRef}
       onMouseDown={handleMouseDown}
       onMouseEnter={() => setMinimapHovered(true)}
-      onMouseLeave={() => { setMinimapHovered(false); setMouseYRatio(null); }}
+      onMouseLeave={() => { setMinimapHovered(false); setMouseYRatio(null); setHoveredTooltipIndex(null); }}
       onMouseMove={handleMinimapMouseMove}
       style={{
         width: MINIMAP_WIDTH,
@@ -417,9 +434,95 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
           zIndex: 0,
         }}
       />
-
-      {/* Tooltips for all nodes, collision-free positions */}
-      {minimapHovered && nodes.map((node, i) => {
+      {/* Tooltip panel: scrollable list when overflowing, absolute-positioned when fits */}
+      {minimapHovered && nodes.length > 0 && tooltipListOverflows && (
+        <div
+          ref={overflowPanelRef}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            right: "100%",
+            width: 206,
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-control)",
+            boxShadow: "var(--shadow-pop)",
+            zIndex: 99,
+            pointerEvents: "auto",
+            overflowY: "auto",
+            overflowX: "hidden",
+          }}
+        >
+          {nodes.map((node) => {
+            const preview = nodePreviews[node.index] ?? getMessagePreview(node.msg);
+            const color = nodeColors[node.index] ?? getNodeColor(node.msg);
+            const isNearest = nearestIndex === node.index;
+            if (!preview) return null;
+            return (
+              <div
+                key={node.index}
+                data-node-index={node.index}
+                onMouseEnter={() => setHoveredTooltipIndex(node.index)}
+                onMouseLeave={() => setHoveredTooltipIndex(null)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const el = scrollContainer.current;
+                  if (!el) return;
+                  el.scrollTop = node.topRatio * el.scrollHeight;
+                }}
+                style={{
+                  padding: "2px 7px",
+                  borderLeft: `2px solid ${color.border}`,
+                  background: isNearest ? "var(--bg-hover)" : "transparent",
+                  cursor: "pointer",
+                  transition: "background var(--dur-fast) var(--ease-out-warm)",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: isNearest ? "var(--text)" : "var(--text-muted)",
+                    lineHeight: 1.4,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {preview}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {minimapHovered && tooltipPositions.length > 0 && (() => {
+        // Opaque backdrop spanning first to last tooltip; width includes the
+        // 6px gutter so the mouse can't fall through the gap between the
+        // minimap strip and the tooltip panel.
+        const firstTop = tooltipPositions[0];
+        const lastBottom = tooltipPositions[tooltipPositions.length - 1] + TOOLTIP_HEIGHT;
+        return (
+          <div
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{
+              position: "absolute",
+              top: firstTop - 4,
+              right: "100%",
+              width: 206,
+              height: lastBottom - firstTop + 8,
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-control)",
+              boxShadow: "var(--shadow-pop)",
+              zIndex: 99,
+              pointerEvents: "auto",
+            }}
+          />
+        );
+      })()}
+      {minimapHovered && !tooltipListOverflows && nodes.map((node, i) => {
         const preview = nodePreviews[i] ?? getMessagePreview(node.msg);
         const color = nodeColors[i] ?? getNodeColor(node.msg);
         const isNearest = nearestIndex === node.index;
@@ -427,23 +530,28 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
         return (
           <div
             key={node.index}
+            onMouseDown={(e) => e.stopPropagation()}
+            onMouseEnter={() => setHoveredTooltipIndex(node.index)}
+            onMouseLeave={() => setHoveredTooltipIndex(null)}
+            onClick={(e) => {
+              e.stopPropagation();
+              const el = scrollContainer.current;
+              if (!el) return;
+              el.scrollTop = node.topRatio * el.scrollHeight;
+            }}
             style={{
               position: "absolute",
               top: tooltipPositions[i],
               right: "100%",
-              marginRight: 6,
-              background: "var(--bg)",
-              borderTop: `1px solid ${isNearest ? color.border : "var(--border)"}`,
-              borderRight: `1px solid ${isNearest ? color.border : "var(--border)"}`,
-              borderBottom: `1px solid ${isNearest ? color.border : "var(--border)"}`,
+              marginRight: 3,
+              background: isNearest ? "var(--bg-hover)" : "var(--bg-panel)",
               borderLeft: `2px solid ${color.border}`,
-              borderRadius: 4,
+              borderRadius: 2,
               padding: "2px 7px",
               width: 200,
               zIndex: 100,
-              pointerEvents: "none",
-              opacity: isNearest ? 1 : 0.45,
-              transition: "top var(--dur-fast) var(--ease-out-warm), opacity var(--dur-fast) var(--ease-out-warm)",
+              cursor: "pointer",
+              transition: "top var(--dur-fast) var(--ease-out-warm), background var(--dur-fast) var(--ease-out-warm)",
             }}
           >
             <div

--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -75,6 +75,7 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
   const dragListenersRef = useRef<{ onMove: (ev: MouseEvent) => void; onUp: () => void } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const overflowPanelRef = useRef<HTMLDivElement>(null);
+  const [minimapHeightPx, setMinimapHeightPx] = useState(600);
   // RAF gate for mousemove so a pixel-level pointer event doesn't re-render
   // the whole minimap (every node + tooltip) on every frame.
   const mouseMoveRafRef = useRef<number | null>(null);
@@ -218,8 +219,10 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
     if (!el) return;
     const scrollable = el.scrollHeight - el.clientHeight;
     if (scrollable <= 0) return;
-    const clamped = Math.max(0, Math.min(1 - viewportRatio, viewportTopRatio));
-    el.scrollTop = (clamped / (1 - viewportRatio)) * scrollable;
+    const denom = 1 - viewportRatio;
+    if (denom < 1e-6) return;
+    const clamped = Math.max(0, Math.min(denom, viewportTopRatio));
+    el.scrollTop = (clamped / denom) * scrollable;
   }, [scrollContainer, viewportRatio]);
 
   // Coalesce mousemove updates to one per animation frame: writing state on
@@ -254,7 +257,9 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
 
     const onMove = (ev: MouseEvent) => {
       if (!draggingRef.current) return;
-      const r = (ev.clientY - rect.top) / rect.height;
+      const curRect = containerRef.current?.getBoundingClientRect();
+      if (!curRect) return;
+      const r = (ev.clientY - curRect.top) / curRect.height;
       scrollToMinimapRatio(r - offset);
     };
     const onUp = () => {
@@ -282,10 +287,20 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
 
 
 
+  // Keep minimap height in state so tooltip layout updates on resize (ref reads don't trigger renders)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setMinimapHeightPx(el.clientHeight || 600);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [visible]);
+
   // Compute collision-free tooltip positions for all nodes
   const TOOLTIP_HEIGHT = 22;
   const TOOLTIP_GAP = 2;
-  const minimapHeightPx = containerRef.current?.clientHeight ?? 600;
   const tooltipListOverflows = nodes.length * (TOOLTIP_HEIGHT + TOOLTIP_GAP) > minimapHeightPx;
 
   // Per-node colors and previews are pure functions of each node's message;
@@ -455,9 +470,9 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
             overflowX: "hidden",
           }}
         >
-          {nodes.map((node) => {
-            const preview = nodePreviews[node.index] ?? getMessagePreview(node.msg);
-            const color = nodeColors[node.index] ?? getNodeColor(node.msg);
+          {nodes.map((node, i) => {
+            const preview = nodePreviews[i] ?? getMessagePreview(node.msg);
+            const color = nodeColors[i] ?? getNodeColor(node.msg);
             const isNearest = nearestIndex === node.index;
             if (!preview) return null;
             return (
@@ -470,7 +485,8 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
                   e.stopPropagation();
                   const el = scrollContainer.current;
                   if (!el) return;
-                  el.scrollTop = node.topRatio * el.scrollHeight;
+                  const max = el.scrollHeight - el.clientHeight;
+                  el.scrollTop = node.topRatio * Math.max(0, max);
                 }}
                 style={{
                   padding: "2px 7px",
@@ -537,7 +553,8 @@ export const ChatMinimap = memo(function ChatMinimap({ messages, scrollContainer
               e.stopPropagation();
               const el = scrollContainer.current;
               if (!el) return;
-              el.scrollTop = node.topRatio * el.scrollHeight;
+              const max = el.scrollHeight - el.clientHeight;
+              el.scrollTop = node.topRatio * Math.max(0, max);
             }}
             style={{
               position: "absolute",

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -11,7 +11,7 @@ import { ExtensionDialog } from "./ExtensionDialog";
 import { SubagentTranscriptDialog } from "./SubagentTranscriptDialog";
 import { ChatMinimap, useMessageRefs } from "./ChatMinimap";
 import { ComposerPanels } from "./ComposerPanels";
-import { CHAT_COLUMN_MAX_WIDTH } from "@/lib/chat-layout";
+import { CHAT_COLUMN_MAX_WIDTH, MINIMAP_WIDTH } from "@/lib/chat-layout";
 import { useAgentSession, type AgentPhase, type NoticeItem, type SubagentInfo } from "@/hooks/useAgentSession";
 import { useAudio } from "@/hooks/useAudio";
 import { useDragDrop } from "@/hooks/useDragDrop";
@@ -60,6 +60,10 @@ function phaseLabel(phase: AgentPhase): string {
 }
 
 const CHAT_COLUMN_PADDING = 16;
+// Symmetric centering halves maxWidth reduction across both sides; compensate
+// so the right clearance (padding + half-reduction) equals the minimap width.
+const MINIMAP_CLEARANCE = 2 * (MINIMAP_WIDTH - CHAT_COLUMN_PADDING);
+const CHAT_COLUMN_MAX_WIDTH_DESKTOP = `min(${CHAT_COLUMN_MAX_WIDTH}px, calc(100% - ${MINIMAP_CLEARANCE}px))`;
 // Trigger the next history page while the sentinel is still this far below
 // the top edge, so a normal upward scroll seamlessly continues into the newly
 // loaded messages. Triggering only at the very top made the load invisible:
@@ -999,7 +1003,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
             pointerEvents: "none",
           }}
         >
-          <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto" }}>
+          <div style={{ maxWidth: isMobile ? CHAT_COLUMN_MAX_WIDTH : CHAT_COLUMN_MAX_WIDTH_DESKTOP, margin: "0 auto" }}>
             <NoticeShelf notices={notices} floating align="right" />
           </div>
         </div>
@@ -1008,7 +1012,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
             users need the scrollbar (Chrome's overlay scrollbar still shows). */}
         <div ref={scrollContainerRef} className={`flex-1 overflow-y-auto pt-6` + (isMobile ? "" : " [scrollbar-width:none]")}>
           <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
-            <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto" }}>
+            <div style={{ maxWidth: isMobile ? CHAT_COLUMN_MAX_WIDTH : CHAT_COLUMN_MAX_WIDTH_DESKTOP, margin: "0 auto" }}>
               <ExtensionStatusBar statuses={extensionStatuses} />
               <ExtensionWidgets widgets={aboveEditorWidgets} />
 

--- a/lib/chat-layout.ts
+++ b/lib/chat-layout.ts
@@ -2,3 +2,8 @@
  *  Kept in one place so the message list, notices shelf, empty state, and
  *  composer cannot drift apart. */
 export const CHAT_COLUMN_MAX_WIDTH = 960;
+
+/** Width of the minimap strip overlaid on the right edge of the chat scroll
+ *  area (desktop only). Used to constrain the centered transcript column so
+ *  it never extends under the minimap on narrow viewports. */
+export const MINIMAP_WIDTH = 36;


### PR DESCRIPTION
## Summary

Fixes #22 (minimap too transparent) and #23 (minimap covers chat text).

## Changes

### Issue #22 - Minimap tooltip transparency

- Tooltip opacity raised from 0.45 to fully opaque
- Opaque backdrop panel using project Tooltip treatment (`var(--bg-panel)`, `var(--border)`, `var(--radius-control)`, `var(--shadow-pop)`)
- Tooltips are now interactive: click to scroll to the message, hover highlights the correct item
- 6px gap between minimap strip and tooltip panel bridged so the list doesn't dismiss when moving the mouse toward it
- Scrollable list panel when tooltips exceed minimap height (prevents overlapping text at the bottom)
- Auto-follow: minimap-driven selection scrolls the overflow panel via effect + `data-node-index` query (avoids inline callback ref churn)
- All hooks run unconditionally before the `if (!visible) return null` early return

### Issue #23 - Minimap covers chat text

- `MINIMAP_WIDTH` shared via `lib/chat-layout.ts`
- Transcript and notices columns constrained with `maxWidth: min(960px, calc(100% - Xpx))` where X is derived from both `MINIMAP_WIDTH` and `CHAT_COLUMN_PADDING` so the formula stays correct if either changes
- Symmetric padding preserved - content stays centered on narrow viewports

## Files changed

- `components/ChatMinimap.tsx` - tooltip interactivity, overflow handling, shared constant import
- `components/ChatWindow.tsx` - desktop column max-width constraint
- `lib/chat-layout.ts` - shared `MINIMAP_WIDTH` constant

## Verification

- Typecheck: clean
- Lint: clean (pre-existing warning in LoginForm.tsx)
- Tests: 3 pre-existing failures in `project-registry.test.mjs` and `worktree.test.mjs` due to macOS `/private/var` vs `/var` symlink canonicalization - unrelated to this change
- CodeRabbit review: 0 findings
- Visually verified in browser: tooltip readability, click-to-navigate, overflow scrolling, narrow viewport clearance