### PR TITLE
fix(files): restore effective per-type security policy for streamed file responses

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -18,6 +18,7 @@ import {
   getDocumentMime,
   getFileExt,
   getImageMime,
+  getStreamSecurityHeaders,
 } from "@/lib/file-types";
 import { resolveDirentIsDirectory } from "@/lib/file-dirent";
 import { isFilePathReferencedBySession } from "@/lib/session-file-references";
@@ -308,6 +309,8 @@ function streamFile(filePath: string, stat: fs.Stats, contentType: string, range
     "Cache-Control": "no-cache",
     "Accept-Ranges": "bytes",
     "Content-Disposition": getContentDisposition(filePath, asDownload),
+    // Shared by the full-body, 206, and 416 paths below.
+    ...getStreamSecurityHeaders(contentType),
   };
 
   if (!rangeHeader) {

--- a/lib/file-types.test.mjs
+++ b/lib/file-types.test.mjs
@@ -32,3 +32,30 @@ test("extracts extensions from mixed path styles", async () => {
   assert.equal(documentPreviewKind("/tmp/manual.PDF"), "pdf");
   assert.equal(documentPreviewKind("/tmp/manual.md"), null);
 });
+
+test("streamed SVG documents carry a script-blocking security policy", async () => {
+  const { getStreamSecurityHeaders, IMAGE_EXT_TO_MIME } = await loadSubject();
+
+  const headers = getStreamSecurityHeaders(IMAGE_EXT_TO_MIME.svg);
+  const csp = headers["Content-Security-Policy"];
+  assert.ok(csp, "SVG responses must set a Content-Security-Policy");
+  // No script-src fallback hole: default-src 'none' governs script loading.
+  assert.match(csp, /(^|; )default-src 'none'/);
+  assert.doesNotMatch(csp, /script-src/);
+  assert.match(csp, /base-uri 'none'/);
+  assert.match(csp, /form-action 'none'/);
+  // Legit SVGs keep inline styles and data-URI images.
+  assert.match(csp, /style-src 'unsafe-inline'/);
+  assert.match(csp, /img-src data:/);
+  // Same-origin framing stays possible; only script execution is blocked.
+  assert.match(csp, /frame-ancestors 'self'/);
+});
+
+test("non-SVG streamed types keep their default headers", async () => {
+  const { getStreamSecurityHeaders } = await loadSubject();
+
+  // <img>/<audio>/document embedding must not change for other MIME types.
+  assert.deepEqual(getStreamSecurityHeaders("image/png"), {});
+  assert.deepEqual(getStreamSecurityHeaders("audio/mpeg"), {});
+  assert.deepEqual(getStreamSecurityHeaders("application/pdf"), {});
+});

--- a/lib/file-types.ts
+++ b/lib/file-types.ts
@@ -60,6 +60,23 @@ export function documentPreviewKind(filePath: string): DocumentPreviewKind | nul
   return null;
 }
 
+/**
+ * SVG is the only streamed preview type a browser executes as a document.
+ * Serving it without a restrictive Content-Security-Policy would let a
+ * repo-controlled SVG, opened as a direct navigation, run script in the
+ * omp-web origin where every /api route is reachable. These headers only
+ * affect document rendering; <img> preview embedding ignores them. The
+ * directives mirror the DOCX preview policy in app/api/files/[...path]/route.ts
+ * so legit SVGs keep inline styles and data-URI images.
+ */
+export function getStreamSecurityHeaders(contentType: string): Record<string, string> {
+  if (contentType !== "image/svg+xml") return {};
+  return {
+    "Content-Security-Policy":
+      "default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'",
+  };
+}
+
 export function isImagePath(filePath: string): boolean {
   return getImageMime(filePath) !== null;
 }

--- a/lib/security-headers.test.mjs
+++ b/lib/security-headers.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRequire } from "node:module";
+import { createJiti } from "jiti";
+
+// The effective policy for a response is decided by next.config's headers()
+// rules, not by the route handler: Next applies config headers last, so a
+// config rule matching the same key overwrites what a handler set. These tests
+// resolve the rules the way Next does (its own path matcher, later rule wins
+// per key), so a regression that re-broadens the global rule fails here instead
+// of silently disabling the per-content-type policy in the files route.
+const require = createRequire(import.meta.url);
+// Same matcher and options Next uses for header rules, see
+// node_modules/next/dist/server/lib/router-utils/filesystem.js buildCustomRoute.
+// The expectations below were cross-checked against a running dev server: an
+// SVG file response carries only the handler policy, while / and
+// /api/file-index carry the global one.
+const { getPathMatch } = require("next/dist/shared/lib/router/utils/path-match");
+// next.config.ts resolves bare specifiers such as `next/constants` the CommonJS
+// way, which plain Node ESM cannot do, so load it through jiti like the
+// component tests do.
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } = await jiti.import("next/constants");
+const nextConfig = await jiti.import("../next.config.ts", { default: true });
+
+async function effectiveHeaders(phase, pathname) {
+  const rules = await nextConfig(phase).headers();
+  const resolved = new Map();
+  for (const rule of rules) {
+    const matches = getPathMatch(rule.source, { removeUnnamedParams: true, strict: true })(pathname);
+    if (matches === false) continue;
+    for (const { key, value } of rule.headers) resolved.set(key.toLowerCase(), value);
+  }
+  return resolved;
+}
+
+const FILE_RESPONSE_PATHS = [
+  "/api/files/home/user/project/logo.svg",
+  "/api/files/home/user/project/docs/report.docx",
+  "/api/files/C%3A/Users/me/project/logo.svg",
+];
+
+for (const phase of [PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER]) {
+  test(`config leaves the document policy of file responses to the route handler (${phase})`, async () => {
+    for (const pathname of FILE_RESPONSE_PATHS) {
+      const headers = await effectiveHeaders(phase, pathname);
+      // A config-level CSP here would overwrite the script-blocking policy the
+      // route handler sets for SVG, and the DOCX preview policy with it.
+      assert.equal(
+        headers.get("content-security-policy"),
+        undefined,
+        `${pathname} must not receive a config-level Content-Security-Policy`,
+      );
+      // Handler-agnostic protections must still arrive.
+      assert.equal(headers.get("x-content-type-options"), "nosniff", pathname);
+      assert.equal(headers.get("referrer-policy"), "no-referrer", pathname);
+      assert.match(headers.get("permissions-policy") ?? "", /camera=\(\)/, pathname);
+      // The app frames its own DOCX/PDF previews; DENY would block them.
+      assert.equal(headers.get("x-frame-options"), "SAMEORIGIN", pathname);
+    }
+  });
+
+  test(`every other route keeps the global security headers (${phase})`, async () => {
+    for (const pathname of ["/", "/login", "/api/file-index", "/api/sessions", "/api/files"]) {
+      const headers = await effectiveHeaders(phase, pathname);
+      const csp = headers.get("content-security-policy");
+      assert.ok(csp, `${pathname} must keep the global Content-Security-Policy`);
+      assert.match(csp, /default-src 'self'/, pathname);
+      assert.match(csp, /frame-ancestors 'none'/, pathname);
+      assert.equal(headers.get("x-content-type-options"), "nosniff", pathname);
+    }
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -55,34 +55,51 @@ const nextConfig = (phase: string): NextConfig => {
         { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
         { key: "Content-Security-Policy", value: "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ws: wss:; font-src 'self' data:" },
       ];
-      const headers = [
-        {
-          source: "/:path*",
-          headers: securityHeaders,
-        },
-        {
-          // Hashed build output never changes, so browsers/proxies may cache it
-          // immutably for a year and skip revalidation entirely.
-          // NOTE: scoped to /_next/static/ only — broader /_next/ patterns would
-          // shadow the HMR WebSocket in development.
-          source: "/_next/static/:path*",
-          headers: [
-            { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
-          ],
-        },
-        {
-          source: "/",
-          headers: [
-            { key: "Cache-Control", value: "private, no-cache, max-age=0, must-revalidate" },
-          ],
-        },
+      // /api/files streams workspace files whose document policy depends on the
+      // content type (strict CSP for SVG, the DOCX preview policy, none for
+      // media the browser renders natively). Config-level headers overwrite
+      // same-key headers set by route handlers, so the global CSP must not
+      // match these paths — it would both reopen script execution for SVG
+      // documents and block the same-origin <iframe> previews (DOCX/PDF) with
+      // frame-ancestors 'none'. The handler-agnostic protections stay here.
+      const fileResponseHeaders = [
+        { key: "X-Content-Type-Options", value: "nosniff" },
+        { key: "X-Frame-Options", value: "SAMEORIGIN" },
+        { key: "Referrer-Policy", value: "no-referrer" },
+        { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
       ];
+      const globalRule = {
+        // Everything except /api/files (negative lookahead, same pattern style
+        // as the proxy matcher).
+        source: "/((?!api/files/).*)",
+        headers: securityHeaders,
+      };
+      const fileRule = {
+        source: "/api/files/:path*",
+        headers: fileResponseHeaders,
+      };
+      const rootNoCacheRule = {
+        source: "/",
+        headers: [
+          { key: "Cache-Control", value: "private, no-cache, max-age=0, must-revalidate" },
+        ],
+      };
+      const staticImmutableRule = {
+        // Hashed build output never changes, so browsers/proxies may cache it
+        // immutably for a year and skip revalidation entirely.
+        // NOTE: scoped to /_next/static/ only — broader /_next/ patterns would
+        // shadow the HMR WebSocket in development.
+        source: "/_next/static/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      };
 
       // Dev chunks have stable URLs whose content changes in place; caching
       // them immutably would serve stale module factories after a restart.
-      if (isDev) return [headers[0], headers[2]];
+      if (isDev) return [globalRule, fileRule, rootNoCacheRule];
 
-      return headers;
+      return [globalRule, fileRule, staticImmutableRule, rootNoCacheRule];
     },
     env: {
       NEXT_PUBLIC_APP_VERSION: version,


### PR DESCRIPTION
I started out adapting the SVG hardening from pi-web (agegr/pi-web@9db0cce) and found the problem here sits one layer deeper, so this PR touches `next.config.ts` as well. Short version: on Next 16, `headers()` from next.config overwrites same-key headers set by route handlers. I confirmed this against a running dev server with a probe header: unique keys from the handler survive, but its `Content-Security-Policy` gets replaced by the global one.

That single behavior causes three bugs on current main:

1. A repo-controlled SVG opened by direct navigation (say, a transcript link like `/api/files/.../logo.svg?type=read`) renders as a document under the global CSP, which allows `script-src 'unsafe-inline'`. Inline script in the SVG runs in the omp-web origin and can call any `/api` route from there. Reproduced with an SVG whose script sets `document.title`.
2. The restrictive CSP the DOCX preview handler already sets (`type=preview` in the files route) never reaches the wire. Dead code since 484735d.
3. The global `frame-ancestors 'none'` and `X-Frame-Options: DENY` land on `/api/files` responses too, so the same-origin iframe previews for DOCX and PDF in FileViewer get blocked. Chromium logs `Framing 'http://127.0.0.1:30178/' violates the following Content Security Policy directive: "frame-ancestors 'none'"`. Also a regression from 484735d.

## The fix

- `next.config.ts`: the global security-header rule now matches everything except `/api/files/` (same negative-lookahead style the proxy matcher uses). `/api/files/:path*` gets its own set that doesn't depend on content type: nosniff, Referrer-Policy, Permissions-Policy, plus `X-Frame-Options: SAMEORIGIN` so our own previews can frame the responses again while other origins still can't.
- Document policy stays in the route handler, because it depends on the content type. `streamFile()` now serves `image/svg+xml` with a script-blocking CSP that mirrors the DOCX preview policy (`getStreamSecurityHeaders()` in `lib/file-types.ts`). The DOCX handler CSP is untouched; it just works again.

Why not slap a strict CSP on all of `/api/files` from the config and be done? Two reasons. Firefox applies response CSP to image documents, so `default-src 'none'` would break opening a plain PNG in a tab. And a config-level CSP is exactly the mechanism that killed the DOCX policy in the first place; I'd rather not plant the same trap for the next handler.

CSP response headers have no effect on `<img>` or `<audio>` embedding, so in-app previews render exactly as before.

## How I verified it

Against a dev server, with Chromium:

- SVG with inline script, direct navigation: before the patch the marker script ran; after, it doesn't, and the image still renders.
- curl on full and Range requests: 200 and 206 both carry the strict CSP (the 416 path shares the same header object).
- `<img>` embedding of the same SVG still loads.
- Same-origin iframes of a PDF and an SVG: blocked before, load after.
- `/` and other API routes such as `/api/file-index` keep the global CSP unchanged.
- `npm run typecheck`, `npm run lint` (two pre-existing warnings in files this PR doesn't touch), `npm test` (424 pass).

## Tests

pi-web's regression test greps the route source and lives under `app/api/files/`, which this repo's test glob doesn't even run. So instead there are behavioral assertions in `lib/file-types.test.mjs`: SVG gets a CSP with no script-src fallback hole and `frame-ancestors 'self'`, other streamed types get none.
