### PR TITLE
fix(rpc): bound the prompt acknowledgement wait

### DIFF
--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -375,3 +375,55 @@ test("get_state timeout recycles wrapper and produces session_unresponsive WebRp
   assert.equal(disposed, true);
   assert.equal(wrapper.isAlive(), false);
 });
+
+test("prompt ack timeout recycles a child that accepts the frame but withholds its response", async (t) => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper, WebRpcError } = jiti("./rpc-manager.ts");
+  const { RpcCommandTimeoutError } = jiti("./omp/rpc-process.ts");
+
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let acceptedPrompt = null;
+  let disposed = false;
+  let removedFromRegistry = false;
+  const fakeProc = {
+    isAlive: true,
+    onFrame: () => () => {},
+    sendCommand: (command, timeoutMs) => {
+      if (command.type !== "prompt") return Promise.resolve({});
+      acceptedPrompt = command;
+      // Model execution is not timed here. This promise represents only the
+      // transport response to the accepted prompt frame.
+      assert.equal(timeoutMs, 30000);
+      return new Promise((_, reject) => {
+        setTimeout(() => reject(new RpcCommandTimeoutError("prompt", timeoutMs)), timeoutMs);
+      });
+    },
+    sendFrame: () => {},
+    dispose: async () => { disposed = true; },
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.onDestroy(() => { removedFromRegistry = true; });
+  wrapper.start();
+
+  const pending = wrapper.send({ type: "prompt", message: "Hello" });
+  await Promise.resolve();
+  assert.deepEqual(acceptedPrompt, { type: "prompt", message: "Hello" });
+  t.mock.timers.tick(30000);
+
+  await assert.rejects(
+    pending,
+    (err) => {
+      assert.ok(err instanceof WebRpcError || err.name === "WebRpcError");
+      assert.equal(err.code, "session_unresponsive");
+      return true;
+    },
+  );
+
+  assert.equal(disposed, true);
+  assert.equal(removedFromRegistry, true);
+  assert.equal(wrapper.isAlive(), false);
+  assert.equal(wrapper.isRunning(), false);
+});
+

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -39,6 +39,13 @@ const IDLE_DESTROY_MS = 10 * 60 * 1000;
 const READY_TIMEOUT_MS = 120_000;
 const MCP_LIST_TIMEOUT_MS = 15_000;
 const GET_STATE_TIMEOUT_MS = 5_000;
+/** Cap on the *acknowledgement* of a prompt frame — not on model execution.
+ * omp acks a prompt as soon as it accepts it and the run then reports through
+ * events (agent_start/agent_end), so an ack that never arrives means the child
+ * is wedged: without this the API request (and the UI spinner behind it) would
+ * stay pending forever. Generous enough to cover slow local startup work the
+ * child does before acking. */
+const PROMPT_ACK_TIMEOUT_MS = 30_000;
 const NON_TERMINAL_CONTINUATION_GRACE_MS = 2_000;
 const AWAITING_AGENT_START_TIMEOUT_MS = 10_000;
 const RESTARTING_MESSAGE = "This session is restarting — retry in a moment.";
@@ -945,7 +952,7 @@ export class AgentSessionWrapper {
             message: command.message as string,
             ...(toImageContents(command.images) ? { images: toImageContents(command.images) } : {}),
             ...(streamingBehavior ? { streamingBehavior } : {}),
-          });
+          }, PROMPT_ACK_TIMEOUT_MS);
           // Slash commands fully consumed by a builtin report agentInvoked:false
           // in the ack itself — no prompt_result frame follows.
           if (ack?.agentInvoked === false && !streamingBehavior) {
@@ -965,6 +972,14 @@ export class AgentSessionWrapper {
           this.awaitingAgentStart = false;
           this.awaitingAgentStartDeadline = 0;
           notifyRunningChange();
+          if (error instanceof RpcCommandTimeoutError || (error instanceof Error && error.name === "RpcCommandTimeoutError")) {
+            // The child took the frame but never acked it, so nothing will ever
+            // report this run: recycle it exactly like the get_state timeout
+            // path so the next request spawns a fresh child instead of talking
+            // to a wedged one.
+            await this.destroyAndWait();
+            throw new WebRpcError("The OMP session stopped responding and was reset.", "session_unresponsive");
+          }
           throw error;
         } finally {
           if (!streamingBehavior) {


### PR DESCRIPTION
Closes #34.

**The problem.** `AgentSessionWrapper.send()` dispatched `prompt` through `RpcProcess.sendCommand()` with no timeout. If the child accepted the stdin write but never returned the RPC response, nothing was left to end the wait: the API request stayed pending forever and the browser sat on `Waiting for model...` with no way back except a reload.

**The fix.** A 30-second cap on the prompt *acknowledgement* only. omp acks a prompt as soon as it accepts it and the run then reports through events, so this does not bound model execution — a turn can still take as long as it takes. An ack that never arrives, on the other hand, means the child is wedged.

When the cap expires the wrapper is treated exactly like the existing `get_state` timeout: prompt-running and pending-dispatch state are cleared, the child is disposed and dropped from the session registry, and the route answers with the established `session_unresponsive` error. The client already rolls a failed submission back and restores the draft, and the next request spawns a fresh child.

Other commands are untouched.

**Tests.** `lib/rpc-manager.test.mjs` drives the real failure shape: the fake child accepts the prompt frame, withholds its response, and a mocked timer advances 30 seconds. The test asserts the frame was accepted, the timeout value applies to the ack, and that the wrapper is disposed, deregistered, no longer alive and no longer running, with `session_unresponsive` surfacing. It fails if either the timeout argument or the recycle is removed.

**Checks.** `npx tsc --noEmit` clean, `npm run lint` clean (the two warnings are pre-existing, in `ChatWindow.tsx` and `LoginForm.tsx`), `npm test` 441 passing.
