### PR TITLE
fix(attachments): share one request budget between composer and agent routes

### DIFF
--- a/app/api/agent/[id]/route.ts
+++ b/app/api/agent/[id]/route.ts
@@ -4,8 +4,7 @@ import { apiErrorResponse, resolveSessionPathOr404 } from "@/lib/api-utils";
 import { startRpcSession, getRpcSession, resolveSpawnCwdResult, WebRpcError } from "@/lib/rpc-manager";
 import { RpcCommandError } from "@/lib/omp/rpc-process";
 import { parseJsonWithinLimit, RequestBodyTooLargeError } from "@/lib/bounded-form-data";
-
-const MAX_AGENT_COMMAND_REQUEST_BYTES = 4 * 1024 * 1024;
+import { MAX_AGENT_COMMAND_REQUEST_BYTES } from "@/lib/image-attachments";
 
 /** omp-web's own failures carry a stable code the client can localize; omp's
  * errors stay opaque English text. */

--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -7,8 +7,7 @@ import { invalidateSessionListCache } from "@/lib/session-reader";
 import { WebRpcError, startRpcSession } from "@/lib/rpc-manager";
 import { RpcCommandError } from "@/lib/omp/rpc-process";
 import { parseJsonWithinLimit, RequestBodyTooLargeError } from "@/lib/bounded-form-data";
-
-const MAX_NEW_AGENT_REQUEST_BYTES = 4 * 1024 * 1024;
+import { MAX_AGENT_COMMAND_REQUEST_BYTES } from "@/lib/image-attachments";
 
 function newSessionErrorResponse(error: unknown) {
   if (error instanceof RequestBodyTooLargeError) {
@@ -34,7 +33,7 @@ function newSessionErrorResponse(error: unknown) {
 // the live model catalog (incl. background discovery) is consulted.
 export async function POST(req: Request) {
   try {
-    const body = await parseJsonWithinLimit<{ cwd?: string; [key: string]: unknown }>(req, MAX_NEW_AGENT_REQUEST_BYTES);
+    const body = await parseJsonWithinLimit<{ cwd?: string; [key: string]: unknown }>(req, MAX_AGENT_COMMAND_REQUEST_BYTES);
     const { cwd, ...command } = body;
 
     if (!cwd || typeof cwd !== "string") {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -21,6 +21,7 @@ import {
   MAX_ATTACHED_IMAGE_BYTES,
   MAX_ATTACHED_IMAGES,
   isBase64ImageWithinLimits,
+  validateOutgoingPrompt,
 } from "@/lib/image-attachments";
 import {
   buildEntriesFromFiles, buildAtInsertText, extractAtQuery, filterFileEntries,
@@ -732,6 +733,17 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
     };
   }, []);
 
+  /** The routes reject an oversized prompt with 413, but the session hook has
+   * already shown the optimistic user bubble and Waiting for model by then, and
+   * the composer has been cleared. Refuse here instead, keeping text and
+   * images so the user can trim the message. */
+  const rejectsOversizedPrompt = useCallback((message: string, images: AttachedImage[]): boolean => {
+    const error = validateOutgoingPrompt(message, images);
+    if (!error) return false;
+    setAttachError(error);
+    return true;
+  }, []);
+
   const handleSend = useCallback(async () => {
     const msg = value.trim();
     if (!msg && !attachedImages.length && !attachedTextFiles.length) return;
@@ -739,15 +751,18 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
     onAudioUnlock?.();
     const composedMessage = composeMessageWithTextAttachments(msg, attachedTextFiles);
     if (!attachedImages.length && !attachedTextFiles.length && msg.startsWith("/") && onBuiltinCommand) {
+      const expansion = expandWebSlashCommand(msg);
+      if (expansion.kind === "expand" && rejectsOversizedPrompt(expansion.prompt, attachedImages)) return;
       const result = await onBuiltinCommand(msg);
       if (result.handled) {
         if (!result.error && !result.retainInput) clearInput();
         return;
       }
     }
+    if (rejectsOversizedPrompt(composedMessage, attachedImages)) return;
     onSend(composedMessage, attachedImages.length ? attachedImages : undefined);
     clearInput();
-  }, [value, attachedImages, attachedTextFiles, isStreaming, onBuiltinCommand, onSend, clearInput, onAudioUnlock]);
+  }, [value, attachedImages, attachedTextFiles, isStreaming, onBuiltinCommand, onSend, clearInput, onAudioUnlock, rejectsOversizedPrompt]);
 
   const slashQuery = value.startsWith("/") && !/\s/.test(value.slice(1))
     ? value.slice(1).toLowerCase()
@@ -1035,6 +1050,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
       // own ACP handlers can run them.
       const expansion = expandWebSlashCommand(msg);
       if (expansion.kind === "expand") {
+        if (rejectsOversizedPrompt(expansion.prompt, attachedImages)) return;
         onPromptWithStreamingBehavior(expansion.prompt, streamingBehavior, attachedImages.length ? attachedImages : undefined);
         clearInput();
         return;
@@ -1046,17 +1062,19 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         }));
         return;
       }
+      if (rejectsOversizedPrompt(msg, attachedImages)) return;
       onPromptWithStreamingBehavior(msg, streamingBehavior, attachedImages.length ? attachedImages : undefined);
       clearInput();
       return;
     }
+    if (rejectsOversizedPrompt(msg, attachedImages)) return;
     if (mode === "steer" && onSteer) {
       onSteer(msg, attachedImages.length ? attachedImages : undefined);
     } else if (mode === "followup" && onFollowUp) {
       onFollowUp(msg, attachedImages.length ? attachedImages : undefined);
     }
     clearInput();
-  }, [value, attachedImages, attachedTextFiles, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput, onAudioUnlock, t, advisorEnabled]);
+  }, [value, attachedImages, attachedTextFiles, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput, onAudioUnlock, t, advisorEnabled, rejectsOversizedPrompt]);
   // A typed, text-only message during a run is a queued follow-up. Keep Stop
   // as the action while the composer is empty or contains attachments.
   const primaryActionQueuesMessage =

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -736,12 +736,14 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
   /** The routes reject an oversized prompt with 413, but the session hook has
    * already shown the optimistic user bubble and Waiting for model by then, and
    * the composer has been cleared. Refuse here instead, keeping text and
-   * images so the user can trim the message. */
+   * images so the user can trim the message.
+   *
+   * The check owns the banner it raises: a dispatch that now fits clears it,
+   * because a text-only prompt has no attachment chip whose removal would. */
   const rejectsOversizedPrompt = useCallback((message: string, images: AttachedImage[]): boolean => {
     const error = validateOutgoingPrompt(message, images);
-    if (!error) return false;
     setAttachError(error);
-    return true;
+    return error !== null;
   }, []);
 
   const handleSend = useCallback(async () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -20,6 +20,7 @@ import { getToolNamesForPreset, type ToolPreset } from "@/lib/tool-presets";
 import { getPreferredToolPreset, setPreferredToolPreset } from "@/lib/tool-preset-preference";
 import { toast } from "@/components/ui/toast";
 import { expandWebSlashCommand } from "@/lib/web-slash-commands";
+import { validateOutgoingPrompt } from "@/lib/image-attachments";
 import { createActiveGoal, parseActiveGoal, type ActiveGoal, type ActivePlan } from "@/lib/web-mode-state";
 import type { HostToolDefinition, HostUriSchemeDefinition, RpcAvailableSlashCommand, SessionStatsInfo, TodoPhase } from "@/lib/pi-types";
 import { isRecord } from "@/lib/type-guards";
@@ -2343,6 +2344,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       return true;
     }
 
+    // This is the final dispatch boundary, after web slash commands have been
+    // expanded. Keep programmatic callers from entering optimistic state with
+    // a body the agent route will reject.
+    const promptError = validateOutgoingPrompt(message, images);
+    if (promptError) {
+      addNotice({ type: "error", message: promptError });
+      return false;
+    }
+
     const promptRunId = promptRunIdRef.current + 1;
     clearTerminalReconcileTimer();
 
@@ -2447,6 +2457,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const sid = sessionIdRef.current;
     if (!sid || !agentRunningRef.current) return false;
 
+    // Same dispatch boundary as handleSend: refuse a body the agent route
+    // would reject with 413 before the optimistic bubble and run state exist.
+    const promptError = validateOutgoingPrompt(trimmedMessage, images);
+    if (promptError) {
+      addNotice({ type: "error", message: promptError });
+      return false;
+    }
+
     clearTerminalReconcileTimer();
     // Advance the run generation so late agent_end / prompt_error / stale
     // loadSession from the aborted turn cannot stop or clobber the replacement.
@@ -2482,9 +2500,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       }
       optimisticUserMessageKeyRef.current = null;
       addNotice({ type: "error", message: e instanceof Error ? e.message : String(e) });
+      // Mirror handleSend: the interrupt never started, so hand the text back
+      // instead of losing it with the rolled-back bubble.
+      if (trimmedMessage) opts.chatInputRef?.current?.insertIfEmpty(trimmedMessage);
       return false;
     }
-  }, [addNotice, ensureEventsConnected, refreshSubagentRoster, clearTerminalReconcileTimer]);
+  }, [addNotice, ensureEventsConnected, refreshSubagentRoster, clearTerminalReconcileTimer, opts.chatInputRef]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;

--- a/lib/api-contract.test.mjs
+++ b/lib/api-contract.test.mjs
@@ -132,6 +132,24 @@ test("mutating agent and MCP routes bound JSON input", async () => {
   assert.match(mcp, /\? 413 : 400/);
 });
 
+test("agent routes bound requests with the shared attachment budget", async () => {
+  const newAgent = await readFile(new URL("../app/api/agent/new/route.ts", import.meta.url), "utf8");
+  const agent = await readFile(new URL("../app/api/agent/[id]/route.ts", import.meta.url), "utf8");
+  const budget = await readFile(new URL("./image-attachments.ts", import.meta.url), "utf8");
+
+  // One source of truth: the composer preflights against the same constant, so
+  // a per-route literal would let the client send bodies the route rejects.
+  for (const route of [newAgent, agent]) {
+    assert.match(route, /import \{ MAX_AGENT_COMMAND_REQUEST_BYTES \} from "@\/lib\/image-attachments"/);
+    assert.match(route, /parseJsonWithinLimit<[^>]*>\(req, MAX_AGENT_COMMAND_REQUEST_BYTES\)/);
+    assert.doesNotMatch(route, /REQUEST_BYTES = /);
+  }
+  // Below Next's 10 MB proxy buffering boundary, with base64 headroom for the
+  // aggregate image cap.
+  assert.match(budget, /MAX_AGENT_COMMAND_REQUEST_BYTES = 8 \* 1024 \* 1024/);
+  assert.match(budget, /MAX_TOTAL_ATTACHED_IMAGE_BYTES = 5 \* 1024 \* 1024/);
+});
+
 test("MCP route redacts project server credentials", async () => {
   const route = await readFile(new URL("../app/api/mcp/route.ts", import.meta.url), "utf8");
   assert.match(route, /redactMcpServer\(config\)/);

--- a/lib/image-attachments.test.mjs
+++ b/lib/image-attachments.test.mjs
@@ -7,6 +7,14 @@ async function loadSubject() {
 
 const image = { type: "image", mimeType: "image/png", data: "YWJj" };
 
+/** Base64 payload decoding to exactly `bytes`. */
+function imageOfBytes(bytes) {
+  const wholeTriplets = Math.floor(bytes / 3);
+  const remainder = bytes % 3;
+  const suffix = remainder === 1 ? "AA==" : remainder === 2 ? "AAA=" : "";
+  return { type: "image", mimeType: "image/png", data: `${"AAAA".repeat(wholeTriplets)}${suffix}` };
+}
+
 test("calculates padded base64 byte lengths and rejects invalid data", async () => {
   const { getBase64DecodedByteLength } = await loadSubject();
 
@@ -22,6 +30,51 @@ test("rejects invalid, oversized, and too many image attachments", async () => {
 
   assert.equal(validateAgentImages([image]), null);
   assert.match(validateAgentImages([{ ...image, mimeType: "text/plain" }]), /valid base64 image/);
-  assert.match(validateAgentImages([{ ...image, data: oversizedData }]), /10MB/);
+  assert.match(validateAgentImages([{ ...image, data: oversizedData }]), /5MB or smaller/);
   assert.match(validateAgentImages(Array.from({ length: MAX_ATTACHED_IMAGES + 1 }, () => image)), /at most/);
+});
+
+test("accepts several screenshots that stay inside the aggregate budget", async () => {
+  const { MAX_TOTAL_ATTACHED_IMAGE_BYTES, validateAgentImages, validateOutgoingPrompt } = await loadSubject();
+  const images = Array.from({ length: 4 }, () => imageOfBytes(MAX_TOTAL_ATTACHED_IMAGE_BYTES / 8));
+
+  assert.equal(validateAgentImages(images), null);
+  assert.equal(validateOutgoingPrompt("Compare these screenshots", images), null);
+});
+
+test("rejects images that individually fit but together exceed the aggregate budget", async () => {
+  const { MAX_ATTACHED_IMAGE_BYTES, MAX_TOTAL_ATTACHED_IMAGE_BYTES, validateAgentImages, validateOutgoingPrompt } = await loadSubject();
+  const half = imageOfBytes(MAX_ATTACHED_IMAGE_BYTES * 0.6);
+  const images = [half, half];
+
+  assert.equal(validateAgentImages([half]), null, "each image alone is within the per-image cap");
+  assert.match(validateAgentImages(images), /total 5MB or less/);
+  assert.match(validateOutgoingPrompt("two big shots", images), /total 5MB or less/);
+  assert.ok(MAX_ATTACHED_IMAGE_BYTES <= MAX_TOTAL_ATTACHED_IMAGE_BYTES);
+});
+
+test("rejects a prompt whose JSON body would exceed the agent request cap", async () => {
+  const { MAX_AGENT_COMMAND_REQUEST_BYTES, MAX_TOTAL_ATTACHED_IMAGE_BYTES, getAgentRequestByteLength, validateOutgoingPrompt } = await loadSubject();
+  const images = [imageOfBytes(MAX_TOTAL_ATTACHED_IMAGE_BYTES)];
+  // Base64 inflates the aggregate image budget to ~6.7 MiB, so the remaining
+  // headroom for text is well under the request cap.
+  const withinBudget = "x".repeat(1024);
+  const overBudget = "x".repeat(MAX_AGENT_COMMAND_REQUEST_BYTES);
+
+  assert.ok(getAgentRequestByteLength(withinBudget, images) > MAX_TOTAL_ATTACHED_IMAGE_BYTES);
+  assert.equal(validateOutgoingPrompt(withinBudget, images), null);
+  assert.match(validateOutgoingPrompt(overBudget, images), /too large to send/);
+  assert.match(validateOutgoingPrompt(overBudget), /too large to send/);
+});
+
+test("validates the expanded web slash prompt rather than its shorter command text", async () => {
+  const { MAX_AGENT_COMMAND_REQUEST_BYTES, validateOutgoingPrompt } = await loadSubject();
+  const { expandWebSlashCommand } = await import("./web-slash-commands.ts");
+  const commandPrefix = "/goal ";
+  const raw = `${commandPrefix}${"x".repeat(MAX_AGENT_COMMAND_REQUEST_BYTES - 256 - 2 - commandPrefix.length - 50)}`;
+  const expansion = expandWebSlashCommand(raw);
+
+  assert.equal(validateOutgoingPrompt(raw), null, "the raw slash command fits");
+  assert.equal(expansion.kind, "expand");
+  assert.match(validateOutgoingPrompt(expansion.prompt), /too large to send/);
 });

--- a/lib/image-attachments.ts
+++ b/lib/image-attachments.ts
@@ -1,9 +1,36 @@
-export const MAX_ATTACHED_IMAGE_BYTES = 10 * 1024 * 1024;
+/**
+ * The attachment budget shared by the composer and the agent routes.
+ *
+ * Next 16.3 buffers a request body in `proxy.ts` before the route handler runs
+ * and rejects anything past its 10 MB default, so the whole JSON command has to
+ * stay under that ceiling. Everything below is derived from it: the request cap
+ * leaves margin under the proxy boundary, and the aggregate image cap leaves
+ * room for base64's 4/3 inflation plus the prompt text inside the request cap.
+ *
+ * Browser-safe by construction (no Node imports): the composer preflights the
+ * exact prompt it is about to send with the same numbers the routes enforce.
+ */
+
+/** Complete JSON body accepted by POST /api/agent/[id] and /api/agent/new. */
+export const MAX_AGENT_COMMAND_REQUEST_BYTES = 8 * 1024 * 1024;
+/** Decoded bytes of all images in one message (~6.7 MiB once base64-encoded). */
+export const MAX_TOTAL_ATTACHED_IMAGE_BYTES = 5 * 1024 * 1024;
+/** Decoded bytes of a single image; a lone image may fill the whole budget. */
+export const MAX_ATTACHED_IMAGE_BYTES = MAX_TOTAL_ATTACHED_IMAGE_BYTES;
 export const MAX_ATTACHED_IMAGES = 10;
+
+/** `{"type":"image","data":"","mimeType":""},` plus slack for the mime type. */
+const IMAGE_ENTRY_OVERHEAD_BYTES = 96;
+/** Command type, streaming behavior, and the surrounding JSON object. */
+const COMMAND_ENVELOPE_BYTES = 256;
 
 export interface Base64ImageAttachment {
   data: string;
   mimeType: string;
+}
+
+function megabytes(bytes: number): number {
+  return bytes / (1024 * 1024);
 }
 
 function isBase64DataChar(code: number): boolean {
@@ -27,30 +54,78 @@ export function getBase64DecodedByteLength(data: string): number | null {
   return (data.length / 4) * 3 - padding;
 }
 
-export function isBase64ImageWithinLimits(value: unknown): value is Base64ImageAttachment {
-  if (!value || typeof value !== "object") return false;
+function getImageByteLengthWithinLimits(value: unknown): number | null {
+  if (!value || typeof value !== "object") return null;
   const image = value as Partial<Base64ImageAttachment>;
   if (typeof image.data !== "string" || typeof image.mimeType !== "string" || !image.mimeType.startsWith("image/")) {
-    return false;
+    return null;
   }
   const bytes = getBase64DecodedByteLength(image.data);
-  return bytes !== null && bytes <= MAX_ATTACHED_IMAGE_BYTES;
+  return bytes !== null && bytes <= MAX_ATTACHED_IMAGE_BYTES ? bytes : null;
+}
+
+export function isBase64ImageWithinLimits(value: unknown): value is Base64ImageAttachment {
+  return getImageByteLengthWithinLimits(value) !== null;
+}
+
+/** Count, per-image, and aggregate rules — the part the composer preflight and
+ * the RPC layer must agree on. Wire-shape checks stay in `validateAgentImages`. */
+function validateImageBudget(images: readonly unknown[]): string | null {
+  if (images.length > MAX_ATTACHED_IMAGES) {
+    return `A message can include at most ${MAX_ATTACHED_IMAGES} images`;
+  }
+  let totalBytes = 0;
+  for (const image of images) {
+    const bytes = getImageByteLengthWithinLimits(image);
+    if (bytes === null) {
+      return `Each image must be valid base64 image data of ${megabytes(MAX_ATTACHED_IMAGE_BYTES)}MB or smaller`;
+    }
+    totalBytes += bytes;
+  }
+  if (totalBytes > MAX_TOTAL_ATTACHED_IMAGE_BYTES) {
+    return `Attached images must total ${megabytes(MAX_TOTAL_ATTACHED_IMAGE_BYTES)}MB or less`;
+  }
+  return null;
 }
 
 /** Return an API-safe error for prompt, steering, and follow-up image arrays. */
 export function validateAgentImages(value: unknown): string | null {
   if (value === undefined) return null;
   if (!Array.isArray(value)) return "images must be an array";
-  if (value.length > MAX_ATTACHED_IMAGES) {
-    return `A message can include at most ${MAX_ATTACHED_IMAGES} images`;
-  }
   for (const image of value) {
     if (!image || typeof image !== "object" || (image as { type?: unknown }).type !== "image") {
       return "Each attachment must be an image";
     }
-    if (!isBase64ImageWithinLimits(image)) {
-      return `Each image must be valid base64 image data of ${MAX_ATTACHED_IMAGE_BYTES / (1024 * 1024)}MB or smaller`;
-    }
+  }
+  return validateImageBudget(value);
+}
+
+/** UTF-8 size of a string once JSON-escaped. */
+function jsonStringByteLength(value: string): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+/** Size of the JSON command body an outgoing prompt produces. Base64 data is
+ * ASCII and needs no escaping, so it is measured by length instead of being
+ * re-serialized. */
+export function getAgentRequestByteLength(message: string, images: readonly Base64ImageAttachment[] = []): number {
+  let bytes = COMMAND_ENVELOPE_BYTES + jsonStringByteLength(message);
+  for (const image of images) {
+    bytes += IMAGE_ENTRY_OVERHEAD_BYTES + image.data.length + jsonStringByteLength(image.mimeType);
+  }
+  return bytes;
+}
+
+/** Preflight for the composer: reject a prompt the agent routes would refuse,
+ * before any optimistic UI state or input clearing happens. */
+export function validateOutgoingPrompt(
+  message: string,
+  images: readonly Base64ImageAttachment[] = [],
+): string | null {
+  const imageError = validateImageBudget(images);
+  if (imageError) return imageError;
+  if (getAgentRequestByteLength(message, images) > MAX_AGENT_COMMAND_REQUEST_BYTES) {
+    return `This message is too large to send: keep it under ${megabytes(MAX_AGENT_COMMAND_REQUEST_BYTES)}MB including attachments.`;
   }
   return null;
 }

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -339,6 +339,31 @@ test("isTerminal:false respects 2-second grace period before raw idle can clear 
   await wrapper.destroyAndWait();
 });
 
+test("abort_and_prompt images go through the same server-side validation as prompt", async () => {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url);
+  const { AgentSessionWrapper } = jiti("./rpc-manager.ts");
+
+  let forwarded = false;
+  const fakeProc = {
+    isAlive: true,
+    onFrame: () => () => {},
+    sendCommand: async () => { forwarded = true; return {}; },
+    sendFrame: () => {},
+    dispose: async () => {},
+  };
+
+  const wrapper = new AgentSessionWrapper(fakeProc, process.cwd());
+  wrapper.start();
+
+  await assert.rejects(
+    wrapper.send({ type: "abort_and_prompt", message: "Hi", images: [{ type: "text", text: "nope" }] }),
+    /Each attachment must be an image/,
+  );
+  assert.equal(forwarded, false, "an invalid attachment must never reach omp");
+  await wrapper.destroyAndWait();
+});
+
 test("get_state timeout recycles wrapper and produces session_unresponsive WebRpcError", async () => {
   const { createJiti } = await import("jiti");
   const jiti = createJiti(import.meta.url);

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -92,6 +92,11 @@ const PASSTHROUGH_COMMANDS = new Set([
   "login",
 ]);
 
+// Commands that can carry user-attached images to the model. All of them must
+// pass the same server-side per-image/count/aggregate validation before the
+// payload reaches omp — a client is free to POST any of them directly.
+const IMAGE_BEARING_COMMANDS = new Set(["prompt", "steer", "follow_up", "abort_and_prompt"]);
+
 // pi-web commands with no omp RPC equivalent. The UI tolerates these failing.
 const UNSUPPORTED_COMMANDS: Record<string, string> = {
   navigate_tree: "Branch navigation is not supported over the omp RPC protocol",
@@ -915,7 +920,7 @@ export class AgentSessionWrapper {
     this.resetIdleTimer();
     const type = command.type as string;
 
-    if (type === "prompt" || type === "steer" || type === "follow_up") {
+    if (IMAGE_BEARING_COMMANDS.has(type)) {
       const imageError = validateAgentImages(command.images);
       if (imageError) throw new Error(imageError);
     }


### PR DESCRIPTION
Closes #33.

**The problem.** The composer accepted up to 10 images of 10MB each, but both agent POST routes capped the whole JSON body at 4MiB. Images travel as base64 inside that body, so two ordinary ~1.7MB screenshots were already over the limit. Nothing warned about it: the request was built, the optimistic user bubble and `Waiting for model...` were already on screen, the composer had been cleared — and only then did the route answer `413`, leaving the user with a lost draft and no attachments.

**The fix.** One budget, defined once in `lib/image-attachments.ts` and used by both the browser and both routes: 8MiB for the complete request, 5MiB for the decoded images inside it, on top of the existing per-image and count checks. 8MiB sits under Next's 10MB proxy buffering default, and 5MiB decoded leaves room for base64's 4/3 expansion plus the prompt text.

The client measures the request it is about to send rather than guessing: JSON-escaped UTF-8 for the message and mime types, raw length for base64 payloads, and fixed allowances for the envelope and per-image JSON that are larger than what the wire actually carries. So the estimate can overshoot by a few hundred bytes but never undershoot, and it compares with the same `>` boundary the server uses.

That check now runs on every path that can reach the routes — send, queued steer, queued follow-up, streaming-behavior prompt, interrupt-and-reply, and web slash commands, which are validated after expansion because `/goal x…` is far shorter than the prompt it becomes. It runs before any optimistic state, so a rejected message keeps its text and its images and reports why in the composer.

`abort_and_prompt` was reaching omp without image validation at all; it now goes through the same server-side check as `prompt`, `steer` and `follow_up`.

**Tests.** `lib/image-attachments.test.mjs` covers the budget math: base64 lengths with padding, four screenshots that fit, two that individually fit but together do not, a body that only exceeds the cap after slash-command expansion, and the request cap itself. `lib/api-contract.test.mjs` asserts both routes import the shared constant instead of carrying their own literal. `lib/rpc-manager.test.mjs` covers the `abort_and_prompt` validation.

**Checks.** `npx tsc --noEmit` clean, `npm run lint` clean (the two warnings are pre-existing, in `ChatWindow.tsx` and `LoginForm.tsx`), `npm test` 446 passing.

By hand against a running instance: two 3.8MB screenshots are refused with text and both thumbnails still in the composer and no request sent; an oversized `/goal` is refused the same way; 7.5MiB reaches the route and fails validation normally, while 8.5MiB returns `413 request_too_large`.
