### PR TITLE
fix(todo): cap the task list and give it its own scrollbar

### DIFF
--- a/components/TodoList.test.mjs
+++ b/components/TodoList.test.mjs
@@ -73,3 +73,65 @@ test("collapsible mode collapses to a toggle header and expands again", () => {
   assert.match(expandedHtml, /aria-expanded="true"/);
   assert.match(expandedHtml, /Wire panels/);
 });
+
+/** A plan long enough that an uncapped panel would run off the viewport. */
+const longPlan = [{
+  name: "Migration",
+  tasks: Array.from({ length: 56 }, (_, i) => ({ content: `Task number ${i + 1}`, status: "pending" })),
+}];
+
+const expandedPanel = () => renderToStaticMarkup(React.createElement(TodoList, {
+  phases: longPlan,
+  collapsible: true,
+  defaultExpanded: true,
+}));
+
+test("the expanded task list is capped and scrolls on its own", () => {
+  const html = expandedPanel();
+
+  // The panel is pinned above the composer, outside the chat scroller, so
+  // without its own cap the tail of a long plan is unreachable.
+  assert.match(html, /max-height:min\(30vh,\s*240px\)/);
+  assert.match(html, /overflow-y:auto/);
+});
+
+/** Index of the `</div>` that closes the div opening at `openIndex`. */
+function divCloseIndex(html, openIndex) {
+  const tags = /<(\/?)div\b[^>]*?>/g;
+  tags.lastIndex = openIndex;
+  let depth = 0;
+  for (let match; (match = tags.exec(html)) !== null; ) {
+    depth += match[1] === "/" ? -1 : 1;
+    if (depth === 0) return match.index;
+  }
+  return -1;
+}
+
+test("the show-all footer stays outside the scrolling area", () => {
+  const html = expandedPanel();
+  const scrollerOpen = html.lastIndexOf("<div", html.indexOf("overflow-y:auto"));
+  assert.notEqual(scrollerOpen, -1);
+
+  // Preview mode renders only the first few tasks, so anchor on the container
+  // itself rather than on any task text: a footer inside the scroller would
+  // scroll away with the very list it controls.
+  const scrollerClose = divCloseIndex(html, scrollerOpen);
+  assert.notEqual(scrollerClose, -1);
+  const footer = html.indexOf("Show all tasks");
+  assert.notEqual(footer, -1);
+  assert.ok(footer > scrollerClose, "footer button must render after the scroll container closes");
+});
+
+test("the scroll area is reachable by keyboard and named", () => {
+  const html = expandedPanel();
+
+  // Todo rows are static text, unlike the button cards of the subagents panel,
+  // so the container itself has to take focus for a keyboard-only reader.
+  assert.match(html, /tabindex="0"/);
+  assert.match(html, /role="group"[^>]*aria-label="Task list"|aria-label="Task list"[^>]*role="group"/);
+
+  // Its name must differ from the enclosing section's, or a screen reader
+  // announces "Tasks" for the region and again for the scroll area inside it.
+  assert.match(html, /<section[^>]*aria-label="Tasks"/);
+  assert.doesNotMatch(html, /role="group"[^>]*aria-label="Tasks"/);
+});

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -82,7 +82,24 @@ export function TodoList({ phases = [], collapsible = false, defaultExpanded = f
       )}
       {!collapsed && (
         <>
-      <div className="grid gap-3 px-3 py-2.5 animate-slide-down">
+      {/* Capped and scrolled like the sibling subagents panel in
+          ComposerPanels. Both panels are pinned above the composer, outside the
+          chat scroller, so an uncapped list runs its own rows off-screen with
+          nothing able to reach them — a 56-task plan was unreadable past the
+          first screenful. The Show all/less footer sits outside this element so
+          it stays put instead of scrolling away with the list.
+          Unlike the subagents panel, whose cards are buttons and therefore
+          reachable by Tab, todo rows are static text: without an explicit
+          tabIndex a keyboard-only reader could not scroll this at all. Its name
+          differs from the section's so a screen reader does not announce
+          "Tasks" twice on the way in. */}
+      <div
+        className="grid gap-3 px-3 py-2.5 animate-slide-down"
+        style={{ maxHeight: "min(30vh, 240px)", overflowY: "auto" }}
+        role="group"
+        aria-label={t("chatWindow.todoPlanScroll")}
+        tabIndex={0}
+      >
         {displayedPhases.map((phase, phaseIndex) => (
           <div key={phase.id ?? `${phase.name}-${phaseIndex}`} className="grid gap-1.5">
             <div className="text-[11px] font-medium text-text-muted">{phase.name}</div>

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -330,6 +330,7 @@
   "chatWindow.todoBlocker": "Blocked: {blocker}",
   "chatWindow.todoList": "Tasks",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",
+  "chatWindow.todoPlanScroll": "Task list",
   "chatWindow.todoProgress": "{done}/{total} complete",
   "chatWindow.todoShowAll": "Show all tasks",
   "chatWindow.todoShowLess": "Show fewer tasks",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -330,6 +330,7 @@
   "chatWindow.todoBlocker": "ブロック中: {blocker}",
   "chatWindow.todoList": "タスク",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",
+  "chatWindow.todoPlanScroll": "タスク一覧",
   "chatWindow.todoProgress": "{done}/{total} 完了",
   "chatWindow.todoShowAll": "すべてのタスクを表示",
   "chatWindow.todoShowLess": "表示を減らす",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -330,6 +330,7 @@
   "chatWindow.todoBlocker": "已阻塞：{blocker}",
   "chatWindow.todoList": "任务",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",
+  "chatWindow.todoPlanScroll": "任务列表",
   "chatWindow.todoProgress": "已完成 {done}/{total}",
   "chatWindow.todoShowAll": "显示全部任务",
   "chatWindow.todoShowLess": "显示更少任务",


### PR DESCRIPTION
Split out of #32 at @kahme247's request; this is the TodoList half, unchanged.

## Problem

The task panel is pinned above the composer, outside the chat scroller, so it grows with the plan and nothing can scroll it. With a 56-task plan, 23 rows sit off-screen — and so does the message input: at 1400x950 the textarea ends up at y=1601, and at 900x400 it overshoots the viewport by 1346px. You cannot read the bottom of your plan, and you cannot type either.

## Fix

The list takes the same height cap the sibling subagents panel already uses (`min(30vh, 240px)`), with its own scrollbar. At 900x400 with both panels expanded, 19px of overshoot remain; closing those would mean deviating from the sibling's cap, and matching it is the whole reason for the number.

The show-all footer stays outside the scroller, so it does not scroll away with the list it controls. Task rows are static text rather than the buttons the roster renders, so the container itself takes focus — without that a keyboard-only reader cannot scroll it at all. Its accessible name differs from the section's, so "Tasks" is not announced twice on the way in.

## Tests

`components/TodoList.test.mjs`: the list is capped and scrolls, the footer sits outside the scroller, and the scroll area is focusable and named.

## Checks

`npm run typecheck`, `npm run lint` (on the touched file) and `npm test` (457 passing, 1 pre-existing skip) are clean.

Closes #31