### PR TITLE
feat(subagents): hoist running agents above settled ones

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1729,6 +1729,19 @@ html.dark .dropdown-surface :is(select, option) {
   background: var(--bg-panel);
   color: var(--text-muted);
 }
+/* Subagent roster chips. The surface and its hover live here rather than in
+   inline styles with mouseenter/mouseleave handlers because the roster reorders
+   when an agent settles: an inline style set on enter would stay painted on a
+   chip that moved out from under the pointer, while the chip that took its
+   place would stay plain until the pointer moved again. */
+.subagent-chip {
+  border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
+  background: var(--bg);
+}
+.subagent-chip:hover {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: var(--bg-hover);
+}
 /* Compact icon-led top-toolbar buttons: consistent 28x28px invisible hit
    areas inside the 36px bar (40px on mobile within the 44px bar) — strong
    default contrast, restrained hover, visible pressed/disabled states. */

--- a/components/ComposerPanels.test.mjs
+++ b/components/ComposerPanels.test.mjs
@@ -205,3 +205,58 @@ test("zero context tokens never print a null gauge", () => {
   assert.match(html, /read/);
 });
 
+/** Order of the roster cards as rendered, by task label. */
+function cardOrder(html) {
+  return [...html.matchAll(/aria-label="[^"]*?·[^"]*?·\s*([^"]+)"/g)].map((match) => match[1]);
+}
+
+const rosterHtml = (subagents) => renderToStaticMarkup(React.createElement(ComposerPanels, {
+  todoPhases: [],
+  subagents,
+  onSelectSubagent: noop,
+  defaultExpanded: true,
+}));
+
+test("running subagents are hoisted above settled ones", () => {
+  const order = cardOrder(rosterHtml([
+    { id: "s1", agent: "scout", status: "completed", task: "finished first", index: 0 },
+    { id: "s2", agent: "worker", status: "started", task: "still running", index: 1 },
+  ]));
+
+  assert.deepEqual(order, ["still running", "finished first"]);
+});
+
+test("launch order survives inside each group", () => {
+  const order = cardOrder(rosterHtml([
+    { id: "s1", agent: "scout", status: "completed", task: "settled one", index: 0 },
+    { id: "s2", agent: "worker", status: "started", task: "running one", index: 1 },
+    { id: "s3", agent: "sonic", status: "aborted", task: "settled two", index: 2 },
+    { id: "s4", agent: "worker", status: "started", task: "running two", index: 3 },
+  ]));
+
+  assert.deepEqual(order, ["running one", "running two", "settled one", "settled two"]);
+});
+
+test("a history entry stuck at started counts as settled", () => {
+  // Its terminal frame never reached the client; it is not active work, so it
+  // must not outrank a live agent.
+  const order = cardOrder(rosterHtml([
+    { id: "s1", agent: "scout", status: "started", task: "stale history", index: 0, source: "history" },
+    { id: "s2", agent: "worker", status: "started", task: "live worker", index: 1, source: "live" },
+  ]));
+
+  assert.deepEqual(order, ["live worker", "stale history"]);
+});
+
+test("an all-running or all-settled roster keeps its incoming order", () => {
+  assert.deepEqual(cardOrder(rosterHtml([
+    { id: "s1", agent: "scout", status: "started", task: "first", index: 0 },
+    { id: "s2", agent: "worker", status: "started", task: "second", index: 1 },
+  ])), ["first", "second"]);
+
+  assert.deepEqual(cardOrder(rosterHtml([
+    { id: "s1", agent: "scout", status: "completed", task: "first", index: 0 },
+    { id: "s2", agent: "worker", status: "failed", task: "second", index: 1 },
+  ])), ["first", "second"]);
+});
+

--- a/components/ComposerPanels.tsx
+++ b/components/ComposerPanels.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import {
   Activity, Bot, ChevronDown,
   CircleDollarSign, Clock3, Cpu, Gauge, GitBranch, Network, RefreshCw,
@@ -121,6 +121,13 @@ function SubagentActivityLine({ subagent }: { subagent: SubagentInfo }) {
   );
 }
 
+/** Active work, as opposed to a settled run. A history entry frozen at
+ * "started" is a finished run whose terminal frame never reached the client,
+ * so `source` has to be part of the test. */
+function isRunningSubagent(subagent: SubagentInfo): boolean {
+  return subagent.source !== "history" && subagent.status === "started";
+}
+
 function SubagentsPanel({ subagents, onSelectSubagent, defaultExpanded = false }: {
   subagents: SubagentInfo[];
   onSelectSubagent: (subagent: SubagentInfo) => void;
@@ -129,7 +136,19 @@ function SubagentsPanel({ subagents, onSelectSubagent, defaultExpanded = false }
 }) {
   const { t } = useI18n();
   const [collapsed, setCollapsed] = useState(!defaultExpanded);
-  const runningCount = subagents.filter((subagent) => subagent.source !== "history" && subagent.status === "started").length;
+  const runningCount = subagents.filter(isRunningSubagent).length;
+  // This panel is a live HUD in a 240px window, so running agents are hoisted
+  // to the top instead of sitting wherever they were launched. Both groups keep
+  // the roster's order. This does trade positional stability away: a card
+  // changes group once, when it settles, but every card behind the mover shifts
+  // with it, and in a wrapping row of chips that reflows the rows after it.
+  // Only terminal frames reorder anything — progress frames leave status alone.
+  const ordered = useMemo(() => {
+    const running = subagents.filter(isRunningSubagent);
+    return running.length === 0 || running.length === subagents.length
+      ? subagents
+      : [...running, ...subagents.filter((subagent) => !isRunningSubagent(subagent))];
+  }, [subagents]);
 
   if (subagents.length === 0) return null;
 
@@ -172,7 +191,7 @@ function SubagentsPanel({ subagents, onSelectSubagent, defaultExpanded = false }
           className="flex flex-wrap gap-1.5 px-3 py-2.5 animate-slide-down"
           style={{ maxHeight: "min(30vh, 240px)", overflowY: "auto" }}
         >
-          {subagents.map((subagent) => {
+          {ordered.map((subagent) => {
             const stateLabel = t(SUBAGENT_STATE_KEYS[subagent.status]);
             const label = `${subagent.agent} · ${stateLabel} · ${subagent.task ?? subagent.description ?? ""}`.replace(/\s+$/, "");
             const live = subagent.source !== "history";
@@ -180,30 +199,20 @@ function SubagentsPanel({ subagents, onSelectSubagent, defaultExpanded = false }
               <button
                 key={subagent.id}
                 type="button"
-                className="ui-focus-ring"
+                className="ui-focus-ring subagent-chip"
                 onClick={() => onSelectSubagent(subagent)}
                 aria-label={label}
                 title={`${label}${subagent.detached ? " (async)" : ""}`}
                 style={{
                   display: "inline-flex", flexDirection: "column", alignItems: "flex-start", gap: 1,
                   maxWidth: 320, padding: "5px 9px",
-                  border: "1px solid color-mix(in srgb, var(--border) 86%, transparent)",
                   borderRadius: "var(--radius-control)",
-                  background: "var(--bg)",
                   fontSize: 11.5,
                   fontFamily: "inherit",
                   cursor: "pointer",
                   color: live && subagent.status === "started" ? "var(--text)" : "var(--text-dim)",
                   opacity: live && subagent.status === "started" ? 1 : 0.72,
                   transition: "border-color var(--dur-fast) var(--ease-out-warm), background var(--dur-fast) var(--ease-out-warm), opacity var(--dur-fast) var(--ease-out-warm)",
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.borderColor = "color-mix(in srgb, var(--accent) 40%, var(--border))";
-                  e.currentTarget.style.background = "var(--bg-hover)";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.borderColor = "color-mix(in srgb, var(--border) 86%, transparent)";
-                  e.currentTarget.style.background = "var(--bg)";
                 }}
               >
                 <span style={{ display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0, maxWidth: "100%" }}>

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -26,6 +26,7 @@ import type { HostToolDefinition, HostUriSchemeDefinition, RpcAvailableSlashComm
 import { isRecord } from "@/lib/type-guards";
 import { subscribeSessionsChanged } from "@/lib/session-change-bus";
 import {
+  mergeSubagentRoster,
   parseSubagentActivityEvent,
   parseSubagentLifecycle,
   parseSubagentProgress,
@@ -130,6 +131,8 @@ function historyEntryToSubagentInfo(entry: SubagentHistoryEntry): SubagentInfo {
     task: entry.task,
     assignment: entry.assignment,
     index: entry.index,
+    parentToolCallId: entry.parentToolCallId,
+    batchSeq: entry.batchSeq,
     sessionFile: entry.sessionFile,
     source: "history",
     detached: entry.detached,
@@ -852,31 +855,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, []);
 
-  // Merge a batch of roster entries, keeping live frames over history.
-  // `skipNewerThan` lets callers refuse to overwrite entries updated by live
-  // frames after a point-in-time snapshot was requested (a snapshot taken
-  // while a child ran must not regress its later terminal lifecycle status).
+  // Merge a batch of roster entries; ordering and live-over-history precedence
+  // live in `mergeSubagentRoster` so both rules stay testable outside React.
   const mergeSubagents = useCallback((incoming: SubagentInfo[], options?: { skipNewerThan?: number }) => {
     if (!incoming.length) return;
-    const skipNewerThan = options?.skipNewerThan;
-    setSubagents((prev) => {
-      const byId = new Map(prev.map((subagent) => [subagent.id, subagent]));
-      for (const entry of incoming) {
-        const existing = byId.get(entry.id);
-        if (existing && skipNewerThan !== undefined && (existing.lastUpdate ?? 0) >= skipNewerThan) continue;
-        if (!existing) {
-          byId.set(entry.id, entry);
-          continue;
-        }
-        if (entry.source === "history" && existing.source !== "history") continue;
-        if (entry.source !== "history" && existing.source === "history") {
-          byId.set(entry.id, entry);
-          continue;
-        }
-        byId.set(entry.id, { ...existing, ...entry });
-      }
-      return [...byId.values()].sort((a, b) => a.index - b.index || a.id.localeCompare(b.id));
-    });
+    setSubagents((prev) => mergeSubagentRoster(prev, incoming, options?.skipNewerThan));
   }, []);
 
   // Recover the ON-DISK roster from the parent session's task toolResults.

--- a/lib/subagent-history.test.mjs
+++ b/lib/subagent-history.test.mjs
@@ -307,3 +307,126 @@ test("completion caps materialized bytes without splitting a codepoint", () => {
   }
 });
 
+/** One task toolResult holding a batch of agents that all number from 0. */
+function taskBatchLine(id, callId, agents, timestamp) {
+  return JSON.stringify({
+    type: "message",
+    id,
+    parentId: null,
+    timestamp,
+    message: {
+      role: "toolResult",
+      toolCallId: callId,
+      toolName: "task",
+      content: [],
+      details: {
+        progress: agents.map((agent, index) => ({
+          index,
+          id: `${callId}_${agent}${index}`,
+          agent,
+          agentSource: "bundled",
+          status: "completed",
+          task: "work",
+        })),
+      },
+    },
+  });
+}
+
+/** The assistant turn that issues the calls, in the order it issued them. */
+function taskCallLine(id, callIds, timestamp) {
+  return JSON.stringify({
+    type: "message",
+    id,
+    parentId: null,
+    timestamp,
+    message: {
+      role: "assistant",
+      content: callIds.map((callId) => ({ type: "toolCall", id: callId, name: "task", arguments: {} })),
+    },
+  });
+}
+
+test("separate task calls keep their agents apart instead of interleaving", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ompweb-subagent-order-"));
+  const sessionFile = join(dir, "2026-08-02T00-00-00_order.jsonl");
+  try {
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: "session", version: 3, id: "parent", timestamp: "2026-08-02T00:00:00.000Z", cwd: "C:\\work" }),
+      taskCallLine("a1", ["callA"], "2026-08-02T00:00:00.500Z"),
+      taskBatchLine("e1", "callA", ["scout", "scout"], "2026-08-02T00:00:01.000Z"),
+      taskCallLine("a2", ["callB"], "2026-08-02T00:04:00.000Z"),
+      taskBatchLine("e2", "callB", ["worker", "worker"], "2026-08-02T00:05:00.000Z"),
+    ].join("\n") + "\n");
+
+    // Both batches number their children 0,1, so ordering by `index` alone
+    // would yield callA_scout0, callB_worker0, callA_scout1, callB_worker1.
+    assert.deepEqual(
+      extractSubagentHistory(sessionFile).map((entry) => entry.id),
+      ["callA_scout0", "callA_scout1", "callB_worker0", "callB_worker1"],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parallel calls follow the order the assistant issued them, not the order they finished", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ompweb-subagent-order-"));
+  const sessionFile = join(dir, "2026-08-02T00-00-00_parallel.jsonl");
+  try {
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: "session", version: 3, id: "parent", timestamp: "2026-08-02T00:00:00.000Z", cwd: "C:\\work" }),
+      // One turn spawns both batches; the slower one is announced first.
+      taskCallLine("a1", ["callSlow", "callFast"], "2026-08-02T00:00:00.500Z"),
+      // Results are appended as each call finishes, so the fast one lands first.
+      taskBatchLine("e1", "callFast", ["sonic"], "2026-08-02T00:00:20.000Z"),
+      taskBatchLine("e2", "callSlow", ["worker"], "2026-08-02T00:09:00.000Z"),
+    ].join("\n") + "\n");
+
+    const roster = extractSubagentHistory(sessionFile);
+    assert.deepEqual(roster.map((entry) => entry.id), ["callSlow_worker0", "callFast_sonic0"]);
+
+    // The ordinal has to travel to the client: a live snapshot and a partial
+    // history fetch both leave it guessing which call came first.
+    assert.deepEqual(roster.map((entry) => entry.batchSeq), [0, 1]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an agent seen only in results keeps its own call's place", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ompweb-subagent-order-"));
+  const sessionFile = join(dir, "2026-08-02T00-00-00_results.jsonl");
+  try {
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: "session", version: 3, id: "parent", timestamp: "2026-08-02T00:00:00.000Z", cwd: "C:\\work" }),
+      taskCallLine("a1", ["zzFirst", "aaSecond"], "2026-08-02T00:00:00.500Z"),
+      taskBatchLine("e1", "zzFirst", ["scout"], "2026-08-02T00:00:01.000Z"),
+      JSON.stringify({
+        type: "message",
+        id: "e2",
+        parentId: null,
+        timestamp: "2026-08-02T00:05:00.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "aaSecond",
+          toolName: "task",
+          content: [],
+          // No progress array: a child that finished before any snapshot was
+          // recorded exists only as a settled result.
+          details: { results: [{ index: 0, id: "aaLateWorker", agent: "worker", exitCode: 0 }] },
+        },
+      }),
+    ].join("\n") + "\n");
+
+    // Ids are chosen so that the old `index` comparator, which tie-breaks
+    // alphabetically, would put the later agent first.
+    assert.deepEqual(
+      extractSubagentHistory(sessionFile).map((entry) => entry.id),
+      ["zzFirst_scout0", "aaLateWorker"],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+

--- a/lib/subagent-history.ts
+++ b/lib/subagent-history.ts
@@ -93,9 +93,32 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
   }
 
   const byId = new Map<string, SubagentHistoryEntry>();
+  // Authoritative launch order: the assistant message that spawns a batch lists
+  // its `task` toolCall blocks in the order the model issued them. Ordering by
+  // toolResult arrival instead would misplace parallel calls, whose results are
+  // appended as each one finishes rather than as each one started.
+  const callOrder = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.type !== "message" || !isRecord(entry.message) || entry.message.role !== "assistant") continue;
+    const content = entry.message.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== "toolCall" || block.name !== "task") continue;
+      const callId = asString(block.id);
+      if (callId !== undefined && !callOrder.has(callId)) callOrder.set(callId, callOrder.size);
+    }
+  }
+
+  // `index` is the position inside ONE `task` call's batch and restarts at 0 for
+  // every call, so sorting by it alone interleaves the agents of separate calls.
+  // Pair it with the ordinal of the call that spawned each agent.
+  const batchSeqById = new Map<string, number>();
+  let batchSeq = -1;
+  let unannouncedCalls = 0;
   const upsert = (entry: SubagentHistoryEntry) => {
     const existing = byId.get(entry.id);
     if (!existing) {
+      batchSeqById.set(entry.id, batchSeq);
       byId.set(entry.id, entry);
       return;
     }
@@ -103,9 +126,14 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
   };
 
   for (const entry of entries) {
-    if (entry.type !== "message" || entry.message?.role !== "toolResult") continue;
-    const message = entry.message as { toolName?: unknown; details?: unknown };
+    if (entry.type !== "message" || !isRecord(entry.message) || entry.message.role !== "toolResult") continue;
+    const message = entry.message;
     if (message.toolName !== "task") continue;
+    const toolCallId = asString(message.toolCallId);
+    // A result whose call block never made it into the file (truncated or
+    // imported session) keeps arrival order, placed after every announced call.
+    const announced = toolCallId !== undefined ? callOrder.get(toolCallId) : undefined;
+    batchSeq = announced ?? callOrder.size + unannouncedCalls++;
     const details = isRecord(message.details) ? message.details : {};
     const progressArr = Array.isArray(details.progress) ? details.progress : [];
     const resultsArr = Array.isArray(details.results) ? details.results : [];
@@ -123,6 +151,7 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
         assignment: progress.assignment,
         description: progress.description,
         index: progress.index ?? 0,
+        ...(toolCallId !== undefined ? { parentToolCallId: toolCallId } : {}),
         lastIntent: progress.lastIntent,
         toolCount: progress.toolCount,
         requests: progress.requests,
@@ -181,6 +210,7 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
         assignment: asString(raw.assignment) ?? prior?.assignment,
         description: asString(raw.description) ?? prior?.description,
         index: asNumber(raw.index) ?? prior?.index ?? 0,
+        ...(toolCallId !== undefined ? { parentToolCallId: toolCallId } : {}),
         lastIntent: asString(raw.lastIntent) ?? prior?.lastIntent,
         toolCount: asNumber(raw.toolCount) ?? prior?.toolCount,
         requests: asNumber(raw.requests) ?? prior?.requests,
@@ -209,6 +239,7 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
           agent: "task",
           status: asyncInfo.state === "completed" ? "completed" : asyncInfo.state === "failed" ? "failed" : "started",
           index: byId.size,
+          ...(toolCallId !== undefined ? { parentToolCallId: toolCallId } : {}),
           transcriptAvailable: false,
         });
       }
@@ -229,6 +260,9 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
   }
   const roster = [...byId.values()];
   for (const entry of roster) {
+    // The client cannot derive this: neither a live snapshot nor a partial
+    // history fetch reveals which call came first.
+    entry.batchSeq = batchSeqById.get(entry.id) ?? 0;
     if (detachedIds.has(entry.id)) entry.detached = true;
     const candidate = join(dir, `${entry.id}.jsonl`);
     const available = existsSync(candidate);
@@ -237,7 +271,11 @@ export function extractSubagentHistory(sessionFilePath: string): SubagentHistory
       entry.transcriptAvailable = true;
     }
   }
-  return roster.sort((a, b) => a.index - b.index || a.id.localeCompare(b.id));
+  return roster.sort((a, b) =>
+    (batchSeqById.get(a.id) ?? 0) - (batchSeqById.get(b.id) ?? 0)
+    || a.index - b.index
+    || a.id.localeCompare(b.id)
+  );
 }
 
 /** Cap on transcript bytes materialized for the dialog (files are small). */

--- a/lib/subagent-types.test.mjs
+++ b/lib/subagent-types.test.mjs
@@ -5,10 +5,107 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
 
 const {
+  mergeSubagentRoster,
   parseSubagentProgress,
   parseSubagentSnapshot,
   parseSubagentActivityEvent,
 } = await jiti.import("./subagent-types.ts");
+
+/** `index` restarts per `task` call, so every batch numbers its own children. */
+const batch = (call, agents, status = "started") =>
+  agents.map((agent, index) => ({
+    id: `${call}_${agent}${index}`, agent, status, index, parentToolCallId: call, source: "live",
+  }));
+
+/** The same batch as the session file reports it, carrying the call's ordinal. */
+const fromFile = (call, batchSeq, agents, status = "completed") =>
+  batch(call, agents, status).map((entry) => ({ ...entry, source: "history", batchSeq }));
+
+const ids = (roster) => roster.map((entry) => entry.id);
+
+test("roster orders batches by the file's call ordinal, not by index", () => {
+  const first = mergeSubagentRoster([], fromFile("callA", 0, ["scout", "scout"]));
+  const roster = mergeSubagentRoster(first, fromFile("callB", 1, ["worker", "worker"]));
+
+  // Ordering by `index` alone would interleave these as A0, B0, A1, B1.
+  assert.deepEqual(ids(roster), ["callA_scout0", "callA_scout1", "callB_worker0", "callB_worker1"]);
+});
+
+test("the file's call order wins over the order a snapshot arrives in", () => {
+  // get_subagents sorts by `index` then SUBAGENT id, so the batch that arrives
+  // first is whichever happens to own the alphabetically smaller child. Here
+  // "Alpha" belongs to the call that was issued second.
+  const snapshot = [
+    { id: "Alpha", agent: "worker", status: "started", index: 0, parentToolCallId: "call_second", source: "live" },
+    { id: "Zebra", agent: "scout", status: "started", index: 0, parentToolCallId: "call_first", source: "live" },
+  ];
+  const reconnected = mergeSubagentRoster([], snapshot);
+
+  // Both calls land on disk. Their real order must take over, even though the
+  // live entries stay in place because they beat the history ones.
+  const corrected = mergeSubagentRoster(reconnected, [
+    { id: "Zebra", agent: "scout", status: "completed", index: 0, parentToolCallId: "call_first", source: "history", batchSeq: 0 },
+    { id: "Alpha", agent: "worker", status: "completed", index: 0, parentToolCallId: "call_second", source: "history", batchSeq: 1 },
+  ]);
+
+  assert.deepEqual(ids(corrected), ["Zebra", "Alpha"]);
+  assert.deepEqual(corrected.map((entry) => entry.source), ["live", "live"]);
+});
+
+test("history arriving in pieces still orders by call, not by what landed first", () => {
+  // Parallel calls: the second one finishes and reaches the file first, so the
+  // client sees it before the call that was actually issued first exists on disk.
+  const fast = mergeSubagentRoster([], fromFile("call_fast", 1, ["sonic"]));
+  const both = mergeSubagentRoster(fast, fromFile("call_slow", 0, ["worker"]));
+
+  assert.deepEqual(ids(both), ["call_slow_worker0", "call_fast_sonic0"]);
+});
+
+test("a batch still missing from disk sits after the calls the file knows", () => {
+  const onDisk = mergeSubagentRoster([], fromFile("call_first", 0, ["scout"]));
+  const running = mergeSubagentRoster(onDisk, batch("call_running", ["worker"]));
+
+  assert.deepEqual(ids(running), ["call_first_scout0", "call_running_worker0"]);
+  assert.equal(running[1].batchSeq, undefined);
+});
+
+test("a terminal frame without an ordinal leaves the card where it was", () => {
+  const roster = mergeSubagentRoster(
+    mergeSubagentRoster([], fromFile("callA", 0, ["scout"])),
+    fromFile("callB", 1, ["worker", "sonic"]),
+  );
+
+  // A lifecycle frame is parsed fresh and carries no ordinal, so the slot has
+  // to survive on the merge side rather than ride in on the payload.
+  const settled = mergeSubagentRoster(roster, [
+    { id: "callB_worker0", agent: "worker", status: "completed", index: 0, parentToolCallId: "callB", source: "live" },
+  ]);
+
+  assert.deepEqual(ids(settled), ids(roster));
+  assert.equal(settled[1].status, "completed");
+  assert.equal(settled[1].batchSeq, 1);
+});
+
+test("a stale snapshot cannot regress status but still hands over the ordinal", () => {
+  const roster = mergeSubagentRoster([], [{ id: "a", agent: "scout", status: "completed", index: 0, source: "live", lastUpdate: 500 }]);
+
+  const stale = mergeSubagentRoster(roster, [{ id: "a", agent: "scout", status: "started", index: 0, source: "history", batchSeq: 3 }], 400);
+
+  assert.equal(stale[0].status, "completed");
+  assert.equal(stale[0].batchSeq, 3);
+});
+
+test("live frames replace a history entry without moving it", () => {
+  const history = mergeSubagentRoster([], fromFile("callA", 0, ["scout", "worker"]));
+
+  const live = mergeSubagentRoster(history, [
+    { id: "callA_worker1", agent: "worker", status: "started", index: 1, parentToolCallId: "callA", source: "live" },
+  ]);
+
+  assert.deepEqual(ids(live), ["callA_scout0", "callA_worker1"]);
+  assert.equal(live[1].source, "live");
+  assert.equal(live[1].batchSeq, 0);
+});
 
 test("parseSubagentProgress copies telemetry and retry state defensively", () => {
   const progress = parseSubagentProgress({

--- a/lib/subagent-types.ts
+++ b/lib/subagent-types.ts
@@ -1,6 +1,7 @@
 // Shared subagent wire + history types (mirrors of oh-my-pi task/types.ts
 // AgentProgress / SubagentLifecyclePayload / SingleResult, kept small and
-// defensive: every field is optional because payloads are parsed leniently).
+// defensive: every field is optional because payloads are parsed leniently),
+// plus the roster fold both the hook and its tests run on (mergeSubagentRoster).
 
 import { asNumber, asString, isRecord } from "./type-guards";
 export type SubagentAgentSource = "bundled" | "user" | "project";
@@ -77,6 +78,11 @@ export interface SubagentHistoryEntry {
   assignment?: string;
   description?: string;
   index: number;
+  /** Id of the `task` call that spawned this agent, and that call's position in
+   * the session's sequence of `task` calls. Together with `index` they place the
+   * agent without relying on the order entries happen to arrive in. */
+  parentToolCallId?: string;
+  batchSeq?: number;
   sessionFile?: string;
   transcriptAvailable: boolean;
   /** True when the spawn was detached/async (parent turn kept working). */
@@ -319,6 +325,9 @@ export interface SubagentInfo {
   assignment?: string;
   sessionFile?: string;
   parentToolCallId?: string;
+  /** Position inside the spawning `task` call's batch. Restarts at 0 for every
+   * call, so it orders siblings but never the roster — pair it with `batchSeq`.
+   * Also the matching key for id-less progress frames. */
   index: number;
   detached?: boolean;
   progress?: SubagentProgress;
@@ -327,4 +336,61 @@ export interface SubagentInfo {
   result?: SubagentHistoryResult;
   /** Roster origin: live frames/snapshots (default) vs on-disk history. */
   source?: "live" | "history";
+  /** Ordinal of the `task` call that spawned this agent, as recorded in the
+   * session file. Authoritative launch order, but only available once that
+   * call's result is on disk — `extractSubagentHistory` supplies it. */
+  batchSeq?: number;
+}
+
+/** Ordinal for sorting: a batch the file has not recorded yet sorts last. */
+const batchSeqOf = (subagent: SubagentInfo): number =>
+  subagent.batchSeq ?? Number.MAX_SAFE_INTEGER;
+
+/** Spawning call first, then position inside that call, then id. */
+export function compareSubagents(a: SubagentInfo, b: SubagentInfo): number {
+  return batchSeqOf(a) - batchSeqOf(b) || a.index - b.index || a.id.localeCompare(b.id);
+}
+
+/**
+ * Fold roster entries into the previous list, ordered by spawning call and then
+ * position within that call.
+ *
+ * Live frames win over on-disk history for the same id. `skipNewerThan` lets a
+ * caller refuse to overwrite entries that live frames touched after a
+ * point-in-time snapshot was requested, so a stale snapshot cannot regress a
+ * child's terminal status.
+ *
+ * `batchSeq` is the one field that survives every precedence rule: only the
+ * session file knows launch order, and the history entry carrying it is often
+ * the one that loses to a newer live frame. A batch the file has not recorded
+ * yet simply sorts last until the next history merge supplies its ordinal.
+ */
+export function mergeSubagentRoster(
+  prev: SubagentInfo[],
+  incoming: SubagentInfo[],
+  skipNewerThan?: number,
+): SubagentInfo[] {
+  const byId = new Map(prev.map((subagent) => [subagent.id, subagent]));
+  for (const entry of incoming) {
+    const existing = byId.get(entry.id);
+    if (!existing) {
+      byId.set(entry.id, entry);
+      continue;
+    }
+    const batchSeq = existing.batchSeq ?? entry.batchSeq;
+    if (skipNewerThan !== undefined && (existing.lastUpdate ?? 0) >= skipNewerThan) {
+      if (batchSeq !== existing.batchSeq) byId.set(entry.id, { ...existing, batchSeq });
+      continue;
+    }
+    if (entry.source === "history" && existing.source !== "history") {
+      if (batchSeq !== existing.batchSeq) byId.set(entry.id, { ...existing, batchSeq });
+      continue;
+    }
+    if (entry.source !== "history" && existing.source === "history") {
+      byId.set(entry.id, { ...entry, batchSeq });
+      continue;
+    }
+    byId.set(entry.id, { ...existing, ...entry, batchSeq });
+  }
+  return [...byId.values()].sort(compareSubagents);
 }


### PR DESCRIPTION
Stacked on #32 (branch includes its commit; the diff collapses to `ComposerPanels.tsx`, its test and one `globals.css` block once #32 lands). Split out as the separate UX PR requested there — presentation stays apart from the sort so neither hides the other's bugs.

## Change

Running agents are hoisted above settled ones in `SubagentsPanel`; each group keeps the roster's order from #32. A history entry frozen at `started` is a finished run whose terminal frame never reached the client, so it counts as settled and does not outrank live work.

This trades positional stability: a card changes group once, when it settles, and the cards behind it shift with it.

Because cards now move, the chip hover moves from inline `onMouseEnter`/`onMouseLeave` styles into a `.subagent-chip` CSS class — an inline hover stayed painted on a chip that had moved out from under the pointer, while the chip that replaced it stayed plain.

## Tests

`components/ComposerPanels.test.mjs`: running cards precede settled ones, order survives inside each group, a history entry stuck at `started` counts as settled, and an all-running or all-settled roster keeps its incoming order.

## Checks

`npm run typecheck`, `npm run lint` (touched file) and the component tests are clean.