### PR TITLE
feat: collapsible composer - minimize input area to a slim pill bar

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -100,9 +100,12 @@ interface Props {
   advisorEnabled?: boolean;
   /** Toggle the per-chat advisor (composer icon + /advisor command). */
   onAdvisorChange?: (enabled: boolean) => void;
+  /** Collapse the entire composer into a minimized bar. */
+  onMinimize?: () => void;
 }
 
 export interface ChatInputHandle {
+  focus: () => void;
   insertText: (text: string) => void;
   insertIfEmpty: (text: string) => void;
   prependText: (text: string) => void;
@@ -399,6 +402,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
   activePlan,
   advisorEnabled,
   onAdvisorChange,
+  onMinimize,
 }: Props, ref) {
   const isMobile = useIsMobile();
   const { t, tn, locale } = useI18n();
@@ -461,6 +465,9 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
   attachedTextFilesRef.current = attachedTextFiles;
 
   useImperativeHandle(ref, () => ({
+    focus() {
+      textareaRef.current?.focus();
+    },
     insertIfEmpty(text: string) {
       const ta = textareaRef.current;
       const current = ta ? ta.value : value;
@@ -1293,6 +1300,13 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         return;
       }
 
+      // Esc minimizes the composer when idle, empty, and no menus open.
+      if (e.key === "Escape" && !isComposing && !isStreaming && onMinimize && value.trim().length === 0) {
+        e.preventDefault();
+        onMinimize();
+        return;
+      }
+
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         if (isStreaming && (onSteer || onFollowUp)) {
@@ -1306,7 +1320,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         }
       }
     },
-    [isStreaming, onSteer, onFollowUp, onAbort, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, value]
+    [isStreaming, onSteer, onFollowUp, onAbort, onMinimize, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, value]
   );
 
   const handleInput = useCallback(() => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
-import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type Ref } from "react";
 import { ChevronDown, ChevronUp, Paperclip, Square } from "lucide-react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { translate, useI18n } from "@/lib/i18n";
@@ -593,6 +593,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
   }, [sessionKeyForPaging]);
   const [selectedSubagent, setSelectedSubagent] = useState<SubagentInfo | null>(null);
   const [composerMinimized, setComposerMinimized] = useState(false);
+  const minimizedExpandRef = useRef<HTMLButtonElement | null>(null);
   // True while the viewport is at/near the conversation bottom. Drives the
   // anchored render window in CommittedTranscript.
   const [nearBottom, setNearBottom] = useState(true);
@@ -802,6 +803,9 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
   const isEmptyNew = isNew && messages.length === 0 && !streamState.isStreaming && !sessionBusy;
   // Reset minimized state on session switch (session-scoped)
   useEffect(() => { setComposerMinimized(false); }, [sessionKeyForPaging]);
+  // The extension dialog renders inside the collapsible composer wrapper;
+  // never let a pending approval prompt sit hidden behind the minimized pill.
+  useEffect(() => { if (extensionDialog) setComposerMinimized(false); }, [extensionDialog]);
   const messageCwd = session?.cwd ?? newSessionCwd ?? undefined;
 
   const availableThinkingLevels = displayModelValue
@@ -845,7 +849,11 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
     };
   }, [advisorRoleSelector, modelList]);
 
-  const handleMinimize = useCallback(() => setComposerMinimized(true), []);
+  const handleMinimize = useCallback(() => {
+    setComposerMinimized(true);
+    /* Focus the pill's expand button after React commits the visibility change */
+    requestAnimationFrame(() => minimizedExpandRef.current?.focus());
+  }, []);
   const handleExpand = useCallback(() => {
     setComposerMinimized(false);
     /* Focus the textarea after React commits the visibility change */
@@ -900,7 +908,10 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
       onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
       cwd={session?.cwd ?? newSessionCwd}
-      onMinimize={handleMinimize}
+      /* The pill bar and chevron only render in the non-empty layout; don't
+         accept Escape-to-minimize in the fresh-chat branch where there is
+         nothing to collapse. */
+      onMinimize={isEmptyNew ? undefined : handleMinimize}
     />
   );
 
@@ -1179,6 +1190,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
           draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
           isStreaming={sessionBusy}
           isCompacting={isCompacting}
+          expandRef={minimizedExpandRef}
           onExpand={handleExpand}
           onAbort={handleAbort}
           onAbortCompaction={handleAbortCompaction}
@@ -1197,7 +1209,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
               aria-label={t("chatWindow.minimizeComposer")}
               style={{
                 display: "flex", alignItems: "center", justifyContent: "center",
-                width: 32, height: 14,
+                width: 44, height: 24,
                 background: "none", border: "none",
                 color: "var(--text-dim)",
                 cursor: "pointer", padding: 0,
@@ -1516,10 +1528,11 @@ function ExtensionCustomPanel({
 }
 
 /** Slim pill bar replacing the full composer when minimized. */
-function MinimizedComposerBar({ draftKey, isStreaming, isCompacting, onExpand, onAbort, onAbortCompaction }: {
+function MinimizedComposerBar({ draftKey, isStreaming, isCompacting, expandRef, onExpand, onAbort, onAbortCompaction }: {
   draftKey?: string;
   isStreaming: boolean;
   isCompacting?: boolean;
+  expandRef?: Ref<HTMLButtonElement>;
   onExpand: () => void;
   onAbort: () => void;
   onAbortCompaction?: () => void;
@@ -1549,6 +1562,7 @@ function MinimizedComposerBar({ draftKey, isStreaming, isCompacting, onExpand, o
         >
           {/* Expand button - fills remaining space */}
           <button
+            ref={expandRef}
             type="button"
             onClick={onExpand}
             title={t("chatWindow.expandComposer")}
@@ -1593,6 +1607,7 @@ function MinimizedComposerBar({ draftKey, isStreaming, isCompacting, onExpand, o
                 else onAbort();
               }}
               title={t("chatInput.stopAgent")}
+              aria-label={t("chatInput.stopAgent")}
               style={{
                 display: "flex", alignItems: "center", gap: 5,
                 height: 26,

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronUp, Paperclip, Square } from "lucide-react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { translate, useI18n } from "@/lib/i18n";
 import { countToolCallBlocks, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
@@ -27,6 +27,7 @@ import {
   restoreScrollTop,
   VISIBLE_PAGE_SIZE,
 } from "@/lib/chat-lazy-load";
+import { getDraft } from "@/lib/draft-store";
 
 interface Props {
   session: SessionInfo | null;
@@ -591,6 +592,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
     }
   }, [sessionKeyForPaging]);
   const [selectedSubagent, setSelectedSubagent] = useState<SubagentInfo | null>(null);
+  const [composerMinimized, setComposerMinimized] = useState(false);
   // True while the viewport is at/near the conversation bottom. Drives the
   // anchored render window in CommittedTranscript.
   const [nearBottom, setNearBottom] = useState(true);
@@ -798,6 +800,8 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
   }, [agentPhase, committedToolCallIds, streamState.streamingMessage]);
 
   const isEmptyNew = isNew && messages.length === 0 && !streamState.isStreaming && !sessionBusy;
+  // Reset minimized state on session switch (session-scoped)
+  useEffect(() => { setComposerMinimized(false); }, [sessionKeyForPaging]);
   const messageCwd = session?.cwd ?? newSessionCwd ?? undefined;
 
   const availableThinkingLevels = displayModelValue
@@ -841,6 +845,12 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
     };
   }, [advisorRoleSelector, modelList]);
 
+  const handleMinimize = useCallback(() => setComposerMinimized(true), []);
+  const handleExpand = useCallback(() => {
+    setComposerMinimized(false);
+    /* Focus the textarea after React commits the visibility change */
+    requestAnimationFrame(() => chatInputRef?.current?.focus());
+  }, [chatInputRef]);
 
   const chatInputElement = (
     <ChatInput
@@ -890,6 +900,7 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
       onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
       cwd={session?.cwd ?? newSessionCwd}
+      onMinimize={handleMinimize}
     />
   );
 
@@ -1162,7 +1173,44 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
         )}
       </div>
 
-      <div className="relative" style={{ flexShrink: 0 }}>
+      {/* Minimized pill bar - shown when composer is collapsed */}
+      {composerMinimized && (
+        <MinimizedComposerBar
+          draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
+          isStreaming={sessionBusy}
+          isCompacting={isCompacting}
+          onExpand={handleExpand}
+          onAbort={handleAbort}
+          onAbortCompaction={handleAbortCompaction}
+        />
+      )}
+
+      {/* Full composer - always mounted; hidden when minimized to preserve ref + state */}
+      <div className="relative" style={{ flexShrink: 0, display: composerMinimized ? "none" : undefined }}>
+        {/* Minimize chevron above the composer area */}
+        <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
+          <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto", display: "flex", justifyContent: "center" }}>
+            <button
+              type="button"
+              onClick={handleMinimize}
+              title={t("chatWindow.minimizeComposer")}
+              aria-label={t("chatWindow.minimizeComposer")}
+              style={{
+                display: "flex", alignItems: "center", justifyContent: "center",
+                width: 32, height: 14,
+                background: "none", border: "none",
+                color: "var(--text-dim)",
+                cursor: "pointer", padding: 0,
+                borderRadius: 4,
+                transition: "color var(--dur-fast) var(--ease-out-warm), background var(--dur-fast) var(--ease-out-warm)",
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "var(--bg-hover)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.background = "none"; }}
+            >
+              <ChevronDown size={14} strokeWidth={1.8} />
+            </button>
+          </div>
+        </div>
         <div
           style={{
             padding: `0 ${CHAT_COLUMN_PADDING}px`,
@@ -1462,6 +1510,109 @@ function ExtensionCustomPanel({
             </Fragment>
           ))}
         </pre>
+      </div>
+    </div>
+  );
+}
+
+/** Slim pill bar replacing the full composer when minimized. */
+function MinimizedComposerBar({ draftKey, isStreaming, isCompacting, onExpand, onAbort, onAbortCompaction }: {
+  draftKey?: string;
+  isStreaming: boolean;
+  isCompacting?: boolean;
+  onExpand: () => void;
+  onAbort: () => void;
+  onAbortCompaction?: () => void;
+}) {
+  const { t } = useI18n();
+
+  /* Read draft text for preview */
+  const draft = draftKey ? getDraft(draftKey) : null;
+  const draftText = draft?.value?.trim() || null;
+  const hasAttachments = (draft?.images?.length ?? 0) > 0 || (draft?.files?.length ?? 0) > 0;
+
+  return (
+    <div style={{ flexShrink: 0, padding: "4px 16px calc(6px + env(safe-area-inset-bottom))" }}>
+      <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0,
+            height: 36,
+            background: "var(--bg)",
+            border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
+            borderRadius: "var(--radius-card)",
+            boxShadow: "var(--shadow-card)",
+            overflow: "hidden",
+          }}
+        >
+          {/* Expand button - fills remaining space */}
+          <button
+            type="button"
+            onClick={onExpand}
+            title={t("chatWindow.expandComposer")}
+            aria-label={t("chatWindow.expandComposer")}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flex: 1,
+              minWidth: 0,
+              height: "100%",
+              padding: "0 14px",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              textAlign: "left",
+            }}
+          >
+            <ChevronUp size={14} strokeWidth={1.8} style={{ flexShrink: 0, color: "var(--text-dim)" }} />
+            {hasAttachments && (
+              <Paperclip size={13} strokeWidth={1.8} style={{ flexShrink: 0, color: "var(--text-muted)" }} />
+            )}
+            <span style={{
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              fontSize: 14,
+              color: draftText ? "var(--text)" : "var(--text-dim)",
+            }}>
+              {draftText ?? t("chatInput.placeholder")}
+            </span>
+          </button>
+
+          {/* Stop button - sibling, only when agent is running */}
+          {isStreaming && (
+            <button
+              type="button"
+              onClick={() => {
+                if (isCompacting && onAbortCompaction) onAbortCompaction();
+                else onAbort();
+              }}
+              title={t("chatInput.stopAgent")}
+              style={{
+                display: "flex", alignItems: "center", gap: 5,
+                height: 26,
+                padding: "0 12px",
+                marginRight: 5,
+                background: "var(--accent-strong)",
+                border: "none",
+                borderRadius: 7,
+                color: "var(--on-accent)",
+                cursor: "pointer",
+                fontSize: 12,
+                fontWeight: 600,
+                flexShrink: 0,
+              }}
+            >
+              <Square size={9} strokeWidth={0} fill="currentColor" aria-hidden="true" />
+              {t("chatInput.stop")}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -327,6 +327,8 @@
   "chatWindow.contextGauge": "{used}/{total} ctx",
   "chatWindow.collapsePanel": "Collapse",
   "chatWindow.expandPanel": "Expand",
+  "chatWindow.minimizeComposer": "Minimize input",
+  "chatWindow.expandComposer": "Expand input",
   "chatWindow.todoBlocker": "Blocked: {blocker}",
   "chatWindow.todoList": "Tasks",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -327,6 +327,8 @@
   "chatWindow.contextGauge": "{used}/{total} 文脈",
   "chatWindow.collapsePanel": "折りたたむ",
   "chatWindow.expandPanel": "展開",
+  "chatWindow.minimizeComposer": "入力を最小化",
+  "chatWindow.expandComposer": "入力を展開",
   "chatWindow.todoBlocker": "ブロック中: {blocker}",
   "chatWindow.todoList": "タスク",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -327,6 +327,8 @@
   "chatWindow.contextGauge": "{used}/{total} 上下文",
   "chatWindow.collapsePanel": "收起",
   "chatWindow.expandPanel": "展开",
+  "chatWindow.minimizeComposer": "最小化输入",
+  "chatWindow.expandComposer": "展开输入",
   "chatWindow.todoBlocker": "已阻塞：{blocker}",
   "chatWindow.todoList": "任务",
   "chatWindow.todoPhaseStatus": "{name} {done}/{total}",


### PR DESCRIPTION
## Summary

Adds a minimize/expand toggle for the entire bottom composer area (ComposerPanels + ChatInput + toolbar). On mobile, this area can consume >50% of the viewport during long-running agent tasks - minimizing reclaims that space for reading.

## Minimized state

A 36px pill bar replaces the visible composer:
- **Expand button** (left, fills available space): chevron-up + truncated draft text preview or placeholder + paperclip icon when attachments present
- **Stop button** (right sibling, only when agent running): accent-colored with square icon

Both are proper sibling `<button>` elements - no nested interactive content.

## Triggers

- **ChevronDown button** centered above the composer area
- **Escape key** when idle (not streaming), input empty, and no menus open

## Design decisions

- **Always mounted**: full composer uses `display: none` when minimized, preserving `chatInputRef`, draft state, attachments, and in-flight updates
- **Focus on expand**: expanding calls `ChatInputHandle.focus()` via `requestAnimationFrame` after React commits the visibility change
- **Session-scoped state**: React state keyed on `sessionKeyForPaging`, resets on session switch and page reload
- **Never auto-expands**: only click/tap restores
- **Universal**: available on both mobile and desktop

## Changes

| File | Change |
|------|--------|
| `components/ChatInput.tsx` | Added `focus()` to `ChatInputHandle`, `onMinimize` prop, Escape-when-idle handler |
| `components/ChatWindow.tsx` | `composerMinimized` state, minimize/expand callbacks, `MinimizedComposerBar` component, chevron-down minimize button |
| `lib/i18n/locales/{en,ja,zh-CN}.json` | `minimizeComposer` / `expandComposer` i18n keys |

## Testing

- TypeScript: clean compile (`tsc --noEmit`)
- ESLint: no new errors
- CodeRabbit: 3 minor findings, all addressed