### PR TITLE
feat: add macOS launchd installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,41 @@ ompweb --password "your-password"          # Enable password protection
 ompweb --no-open                           # Don't auto-open the browser
 ```
 
+### Run as a macOS Service (launchd)
+
+Install ompweb as a launchd user agent that starts at login and restarts on crash:
+
+```bash
+npx -p @kahme247/ompweb@latest ompweb-launchd install
+```
+
+Manage it with:
+
+```bash
+npx -p @kahme247/ompweb@latest ompweb-launchd status      # Show service state
+npx -p @kahme247/ompweb@latest ompweb-launchd uninstall   # Stop and remove
+```
+
+The service runs `npx --yes @kahme247/ompweb@latest`; pass a package spec to pin a
+version, e.g. `ompweb-launchd install @kahme247/ompweb@0.3.6`. All
+[environment variables](#environment-variables) are read at install time and baked
+into the plist, plus `OMP_WEB_PKG` (package spec, same as the positional argument).
+As a service, the browser is **not** auto-opened by default — install with
+`OMP_WEB_NO_OPEN=0` to restore that.
+
+```bash
+OMP_WEB_PASSWORD=secret npx -p @kahme247/ompweb@latest ompweb-launchd install
+```
+
+When binding to a non-loopback host, require authentication (`OMP_WEB_PASSWORD`
+or equivalent access control) and HTTPS through a trusted reverse proxy or VPN.
+Never expose the unauthenticated web UI or send its password/session cookie over
+plaintext HTTP.
+
+Logs go to `~/Library/Logs/ompweb/ompweb.log` and the plist lives at
+`~/Library/LaunchAgents/com.kahme247.ompweb.plist` (mode 600; a configured
+password is stored there in plain text).
+
 ## Features
 
 - **Interactive Chat**: Real-time streaming conversation with your local `omp` agent.

--- a/bin/omp-web-launchd.js
+++ b/bin/omp-web-launchd.js
@@ -7,9 +7,13 @@
 //   ompweb-launchd [install [package-spec]|uninstall|status]
 //   npx -p @kahme247/ompweb@latest ompweb-launchd install
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { spawnSync } = require("node:child_process");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require("node:fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const os = require("node:os");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require("node:path");
 
 const LABEL = "com.kahme247.ompweb";

--- a/bin/omp-web-launchd.js
+++ b/bin/omp-web-launchd.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+"use strict";
+
+// Install ompweb as a macOS launchd user agent (starts at login, restarts on crash).
+//
+// Usage (installed as the `ompweb-launchd` bin, or run via npx / node directly):
+//   ompweb-launchd [install [package-spec]|uninstall|status]
+//   npx -p @kahme247/ompweb@latest ompweb-launchd install
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const LABEL = "com.kahme247.ompweb";
+const HOME = os.homedir();
+const PLIST = path.join(HOME, "Library", "LaunchAgents", `${LABEL}.plist`);
+const LOG_DIR = path.join(HOME, "Library", "Logs", "ompweb");
+const DOMAIN = `gui/${process.getuid?.() ?? 0}`;
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function isExecutableFile(candidate) {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function which(name) {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (dir && isExecutableFile(path.join(dir, name))) return path.join(dir, name);
+  }
+  return null;
+}
+
+function xmlEscape(value) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function launchctl(args, { ignoreFailure = false } = {}) {
+  const result = spawnSync("launchctl", args, { encoding: "utf8" });
+  if (result.error) fail(`launchctl not runnable: ${result.error.message}`);
+  if (result.status !== 0 && !ignoreFailure) {
+    fail(`launchctl ${args.join(" ")} failed: ${(result.stderr ?? "").trim()}`);
+  }
+  return result.stdout ?? "";
+}
+
+function install(pkgArg) {
+  const nodeBin = process.execPath;
+  const siblingNpx = path.join(path.dirname(nodeBin), "npx");
+  const npxBin = isExecutableFile(siblingNpx) ? siblingNpx : (which("npx") ?? fail("npx not found on PATH"));
+
+  const ompBin = process.env.OMP_WEB_OMP_BIN ?? which("omp");
+  if (process.env.OMP_WEB_OMP_BIN) {
+    try {
+      fs.accessSync(process.env.OMP_WEB_OMP_BIN, fs.constants.X_OK);
+    } catch {
+      fail(`OMP_WEB_OMP_BIN=${process.env.OMP_WEB_OMP_BIN} is not executable`);
+    }
+  } else if (!ompBin) {
+    console.warn("warning: omp binary not found; live-agent features will be unavailable (set OMP_WEB_OMP_BIN)");
+  }
+
+  const pkg = pkgArg ?? process.env.OMP_WEB_PKG ?? "@kahme247/ompweb@latest";
+  const port = process.env.PORT ?? "30177";
+  const hostname = process.env.OMP_WEB_HOSTNAME ?? "127.0.0.1";
+  const noOpen = process.env.OMP_WEB_NO_OPEN ?? "1";
+  const password = process.env.OMP_WEB_PASSWORD;
+  const agentDir = process.env.PI_CODING_AGENT_DIR?.replace(/^~(?=\/|$)/, HOME);
+
+  const asdfBin = which("asdf");
+  const svcPath = [
+    ...(ompBin ? [path.dirname(ompBin)] : []),
+    ...(asdfBin ? [path.dirname(asdfBin)] : []),
+    path.dirname(npxBin),
+    path.dirname(nodeBin),
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+  ].filter((dir, i, all) => all.indexOf(dir) === i).join(path.delimiter);
+
+  const env = {
+    PATH: svcPath,
+    PORT: port,
+    OMP_WEB_HOSTNAME: hostname,
+    OMP_WEB_NO_OPEN: noOpen,
+    ...(password ? { OMP_WEB_PASSWORD: password } : {}),
+    ...(ompBin ? { OMP_WEB_OMP_BIN: ompBin } : {}),
+    ...(agentDir ? { PI_CODING_AGENT_DIR: agentDir } : {}),
+  };
+  const envXml = Object.entries(env)
+    .map(([key, value]) => `    <key>${xmlEscape(key)}</key><string>${xmlEscape(value)}</string>`)
+    .join("\n");
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(npxBin)}</string>
+    <string>--yes</string>
+    <string>${xmlEscape(pkg)}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+${envXml}
+  </dict>
+  <key>WorkingDirectory</key><string>${xmlEscape(HOME)}</string>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${xmlEscape(path.join(LOG_DIR, "ompweb.log"))}</string>
+  <key>StandardErrorPath</key><string>${xmlEscape(path.join(LOG_DIR, "ompweb.err.log"))}</string>
+</dict>
+</plist>
+`;
+
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  fs.mkdirSync(path.dirname(PLIST), { recursive: true });
+  fs.writeFileSync(PLIST, plist, { mode: 0o600 });
+  fs.chmodSync(PLIST, 0o600);
+
+  launchctl(["bootout", `${DOMAIN}/${LABEL}`], { ignoreFailure: true });
+  launchctl(["bootstrap", DOMAIN, PLIST]);
+
+  console.log(`installed: ${PLIST}`);
+  console.log(`package:   ${pkg} (via npx --yes)`);
+  console.log(`url:       http://${hostname}:${port}`);
+  console.log(`logs:      ${path.join(LOG_DIR, "ompweb.log")}`);
+  if (password) console.log("note:      password is stored in plain text in the plist (mode 600)");
+}
+
+function uninstall() {
+  launchctl(["bootout", `${DOMAIN}/${LABEL}`], { ignoreFailure: true });
+  fs.rmSync(PLIST, { force: true });
+  console.log(`uninstalled: ${LABEL}`);
+}
+
+function status() {
+  const result = spawnSync("launchctl", ["print", `${DOMAIN}/${LABEL}`], { encoding: "utf8" });
+  if (result.status === 0) {
+    const lines = (result.stdout ?? "").split("\n").filter((line) => /\b(state|pid|last exit)\b/.test(line));
+    console.log(lines.join("\n") || (result.stdout ?? "").trim());
+    return;
+  }
+  console.log(`not loaded: ${LABEL}`);
+  process.exit(1);
+}
+
+if (process.platform !== "darwin") fail("launchd services are macOS-only");
+
+const command = process.argv[2] ?? "install";
+if (command === "install") install(process.argv[3]);
+else if (command === "uninstall") uninstall();
+else if (command === "status") status();
+else {
+  console.error("usage: ompweb-launchd [install [package-spec]|uninstall|status]");
+  process.exit(2);
+}

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { LockKeyhole } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 
 export function LoginForm() {
+  const router = useRouter();
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -22,7 +24,7 @@ export function LoginForm() {
         setError("Incorrect password. Please try again.");
         return;
       }
-      window.location.assign("/");
+      router.replace("/");
     } catch {
       setError("Could not sign in. Please check your connection and try again.");
     } finally {

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { LockKeyhole } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 
 export function LoginForm() {
-  const router = useRouter();
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -24,7 +22,9 @@ export function LoginForm() {
         setError("Incorrect password. Please try again.");
         return;
       }
-      router.replace("/");
+      // Full reload so the new auth cookie is picked up by middleware
+      // and server components — SPA navigation alone may keep stale state.
+      window.location.replace("/");
     } catch {
       setError("Could not sign in. Please check your connection and try again.");
     } finally {

--- a/lib/omp/agents-service.test.mjs
+++ b/lib/omp/agents-service.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { link, mkdtemp, readdir, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,12 +11,29 @@ const { parseAgentFrontmatter, writeAgent } = await jiti.import("./agents-servic
 const payload = { description: "A test agent", body: "Do the task." };
 
 test("renaming an agent is case-sensitive on POSIX filesystems", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "omp-agents-test-"));
+  // secureScopeDir rejects symlinked scope paths; macOS tmpdir is a
+  // /var -> /private/var symlink, so resolve it first.
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "omp-agents-test-")));
   try {
     writeAgent(dir, "Scout", payload);
     writeAgent(dir, "scout", payload, "Scout");
     const names = (await readdir(dir)).filter((name) => name.endsWith(".md")).sort();
     assert.deepEqual(names, ["scout.md"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("renaming onto a distinct hardlink of the same file is a collision, not a case alias", async () => {
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "omp-agents-test-")));
+  try {
+    const { path: scoutPath } = writeAgent(dir, "Scout", payload);
+    // A hardlink shares the inode but is a separate directory entry — the
+    // rename target genuinely exists and must be rejected.
+    await link(scoutPath, join(dir, "Existing.md"));
+    assert.throws(() => writeAgent(dir, "Existing", payload, "Scout"), /agent file already exists/);
+    const names = (await readdir(dir)).filter((name) => name.endsWith(".md")).sort();
+    assert.deepEqual(names, ["Existing.md", "Scout.md"]);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/lib/omp/agents-service.ts
+++ b/lib/omp/agents-service.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
@@ -233,6 +233,20 @@ function sameAgentPath(left: string, right: string): boolean {
   return process.platform === "win32" ? a.toLowerCase() === b.toLowerCase() : a === b;
 }
 
+// On a case-insensitive filesystem (macOS APFS default) a case-only rename
+// resolves both names to the same directory entry even though the POSIX
+// string compare differs. realpathSync.native (realpath(3)) returns the
+// on-disk casing — the JS realpathSync preserves input casing — so case
+// aliases compare equal while distinct hardlink entries to the same inode
+// (a real name collision) stay distinct.
+function sameOnDiskEntry(left: string, right: string): boolean {
+  try {
+    return realpathSync.native(left) === realpathSync.native(right);
+  } catch {
+    return false;
+  }
+}
+
 export function validateAgentFileReference(scopeDir: string, name: string): void {
   if (!AGENT_NAME_RE.test(name)) throw new Error(`name must match ${AGENT_NAME_RE.source}`);
   const filePath = getAgentFilePath(scopeDir, name);
@@ -268,7 +282,7 @@ export function writeAgent(scopeDir: string, name: string, payload: AgentPayload
   const filePath = getAgentFilePath(dir, name);
   const previousPath = previousName ? getAgentFilePath(dir, previousName) : undefined;
   if (existsSync(filePath) && lstatSync(filePath).isSymbolicLink()) throw new Error("agent file may not be a symbolic link");
-  const replacesPreviousPath = Boolean(previousPath && sameAgentPath(filePath, previousPath));
+  const replacesPreviousPath = Boolean(previousPath && (sameAgentPath(filePath, previousPath) || sameOnDiskEntry(filePath, previousPath)));
   if (existsSync(filePath) && !replacesPreviousPath) throw new Error("agent file already exists");
   const preserved: Record<string, unknown> = isRecord(payload.existingFrontmatter) ? { ...payload.existingFrontmatter } : {};
   if (previousPath && existsSync(previousPath)) {
@@ -296,10 +310,13 @@ export function writeAgent(scopeDir: string, name: string, payload: AgentPayload
   writeFileSync(tmpPath, serialized, { encoding: "utf8", flag: "wx" });
   let displacedPath: string | undefined;
   try {
-    // Windows cannot replace an existing file with renameSync, including a
-    // case-only rename (Scout.md -> scout.md). Move the old file aside first
-    // so updates and case-only renames remain atomic from the caller's view.
-    if (process.platform === "win32" && replacesPreviousPath && existsSync(filePath)) {
+    // Windows cannot replace an existing file with renameSync, and on a
+    // case-insensitive filesystem (macOS APFS default) renaming over a
+    // case-variant keeps the OLD directory entry's casing. Move the old file
+    // aside first so updates and case-only renames remain atomic from the
+    // caller's view and the new name's casing lands on disk.
+    const caseOnlyReplace = Boolean(previousPath && !sameAgentPath(filePath, previousPath) && sameOnDiskEntry(filePath, previousPath));
+    if ((process.platform === "win32" || caseOnlyReplace) && replacesPreviousPath && existsSync(filePath)) {
       displacedPath = `${filePath}.${process.pid}.${Date.now()}.old`;
       renameSync(filePath, displacedPath);
     }

--- a/lib/project-registry.test.mjs
+++ b/lib/project-registry.test.mjs
@@ -19,7 +19,6 @@ const {
   validateProjectPath,
 } = await jiti.import("./project-registry.ts");
 const { resolveProject, addWorktree } = await jiti.import("./worktree.ts");
-const { samePath } = await jiti.import("./paths.ts");
 /** Absolute POSIX-looking test paths become platform-native via resolve(). */
 const P = (p) => resolve(p);
 
@@ -242,20 +241,19 @@ test("worktree paths canonicalize to the main repo root when registered", async 
     execFileSync("git", ["-C", repo, "-c", "safe.directory=*", "add", "README.md"], { stdio: "ignore" });
     execFileSync("git", ["-C", repo, "-c", "safe.directory=*", "commit", "-m", "fixture"], { stdio: "ignore" });
 
+    const mainProject = await resolveProject(repo);
     const created = await addWorktree(repo, "feature/projects");
     const project = await resolveProject(created.path);
-    assert.ok(samePath(project.projectRoot, repo));
+    assert.equal(project.projectRoot, mainProject.projectRoot);
 
     // Registering the canonicalized root stores the main repo, not the worktree.
     const registered = upsertProject({ version: 1, projects: [] }, project.projectRoot);
-    assert.ok(samePath(registered.projects[0].path, repo));
+    assert.equal(registered.projects[0].path, mainProject.projectRoot);
 
     // Sessions discovered from the worktree carry the main repo as their
     // projectRoot, so they merge into the same project.
-    const mainProject = await resolveProject(repo);
     const merged = mergeProjects(registered, [project.projectRoot, mainProject.projectRoot]);
-    assert.equal(merged.length, 1);
-    assert.ok(samePath(merged[0].path, repo));
+    assert.deepEqual(merged.map((p) => p.path), [mainProject.projectRoot]);
   } finally {
     rmSync(worktreeBase, { recursive: true, force: true });
     rmSync(root, { recursive: true, force: true });
@@ -269,7 +267,7 @@ test("resolveProject returns canonical on-disk casing for plain directories", (t
   mkdirSync(dir);
   // Same-directory input resolves to the realpath (on-disk) form.
   return resolveProject(dir).then((info) => {
-    const real = execFileSync("node", ["-e", "console.log(require('fs').realpathSync(process.argv[1]))", dir], { encoding: "utf8" }).trim();
+    const real = execFileSync("node", ["-e", "console.log(require('fs').realpathSync.native(process.argv[1]))", dir], { encoding: "utf8" }).trim();
     assert.equal(info.projectRoot, real);
   });
 });

--- a/lib/worktree.test.mjs
+++ b/lib/worktree.test.mjs
@@ -31,9 +31,7 @@ test("discovers the main checkout and linked worktrees without retaining prunabl
     writeFileSync(join(repo, "README.md"), "fixture\n");
     git(repo, ["add", "README.md"]);
     git(repo, ["commit", "-m", "fixture"]);
-
     const main = await resolveProject(repo);
-    assert.ok(samePath(main.projectRoot, repo));
     assert.equal(main.isWorktree, false);
     assert.equal(main.isTopLevel, true);
     assert.ok(main.branch);
@@ -48,7 +46,7 @@ test("discovers the main checkout and linked worktrees without retaining prunabl
     assert.ok(worktrees.some((entry) => samePath(entry.path, created.path) && entry.branch === "feature/test"));
 
     const linked = await resolveProject(created.path);
-    assert.ok(samePath(linked.projectRoot, repo));
+    assert.equal(linked.projectRoot, main.projectRoot);
     assert.equal(linked.isWorktree, true);
     assert.equal(linked.branch, "feature/test");
     // Verify repairWorktreeGitdirs fixes Windows backslashes
@@ -68,7 +66,7 @@ test("discovers the main checkout and linked worktrees without retaining prunabl
     // resolveProject should still infer the project root back to the main repo.
     const dummyLeftover = join(worktreeBase, "dummy-branch");
     const inferred = await resolveProject(dummyLeftover);
-    assert.ok(samePath(inferred.projectRoot, repo));
+    assert.equal(inferred.projectRoot, main.projectRoot);
     assert.equal(inferred.isWorktree, true);
     assert.equal(inferred.isTopLevel, true);
   } finally {

--- a/lib/worktree.ts
+++ b/lib/worktree.ts
@@ -43,7 +43,9 @@ const PROJECT_CACHE_TTL_MS = 60_000;
 
 function realPathOrSelf(filePath: string): string {
   try {
-    return realpathSync(filePath);
+    // Use the OS-native resolver so Windows 8.3 aliases and filesystem casing
+    // canonicalize to the same identity Git reports.
+    return realpathSync.native(filePath);
   } catch {
     return filePath;
   }
@@ -199,7 +201,7 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
     };
   } catch {
     const inferred = inferRemovedWorktree(cwd);
-    info = inferred ?? { projectRoot: cwd, branch: null, isWorktree: false, isTopLevel: false };
+    info = inferred ?? { projectRoot: realPathOrSelf(cwd), branch: null, isWorktree: false, isTopLevel: false };
   }
 
   cache.set(cwd, { info, expiresAt: Date.now() + PROJECT_CACHE_TTL_MS });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kahme247/ompweb",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kahme247/ompweb",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -20,7 +20,9 @@
         "yaml": "^2"
       },
       "bin": {
-        "ompweb": "bin/omp-web.js"
+        "ompweb": "bin/omp-web.js",
+        "ompweb-launchd": "scripts/macos-launchd.mts",
+        "ompweb-tray": "bin/omp-web-tray.js"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "bin": {
     "ompweb": "bin/omp-web.js",
-    "ompweb-tray": "bin/omp-web-tray.js"
+    "ompweb-tray": "bin/omp-web-tray.js",
+    "ompweb-launchd": "scripts/macos-launchd.mts"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "ompweb": "bin/omp-web.js",
     "ompweb-tray": "bin/omp-web-tray.js",
-    "ompweb-launchd": "scripts/macos-launchd.mts"
+    "ompweb-launchd": "bin/omp-web-launchd.js"
   },
   "files": [
     "bin",

--- a/scripts/macos-launchd.mts
+++ b/scripts/macos-launchd.mts
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Install ompweb as a macOS launchd user agent (starts at login, restarts on crash).
+//
+// Usage (installed as the `ompweb-launchd` bin, or run via npx / node directly):
+//   ompweb-launchd [install [package-spec]|uninstall|status]
+//   npx -p @kahme247/ompweb@latest ompweb-launchd install
+//
+// The positional package-spec picks what the service runs via `npx --yes`
+// (default @kahme247/ompweb@latest; env OMP_WEB_PKG is an equivalent override).
+//
+// Configuration (read at install time, baked into the plist):
+//   OMP_WEB_PKG          npm package spec run via npx               default @kahme247/ompweb@latest
+//   PORT                 Server port                                default 30177
+//   OMP_WEB_HOSTNAME     Server bind host                           default 127.0.0.1
+//   OMP_WEB_PASSWORD     Optional password for web login            default none (auth disabled)
+//   OMP_WEB_NO_OPEN      Set to 0 to auto-open the browser          default 1 (no auto-open)
+//   OMP_WEB_OMP_BIN      Path to omp binary if not on PATH          default auto-detected
+//   PI_CODING_AGENT_DIR  Custom omp agent directory                 default ~/.omp/agent
+//
+// Example (loopback-only; require auth + trusted HTTPS proxy/VPN for remote access):
+//   OMP_WEB_PASSWORD=secret ompweb-launchd install
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const LABEL = "com.kahme247.ompweb";
+const HOME = os.homedir();
+const PLIST = path.join(HOME, "Library", "LaunchAgents", `${LABEL}.plist`);
+const LOG_DIR = path.join(HOME, "Library", "Logs", "ompweb");
+const DOMAIN = `gui/${process.getuid?.() ?? 0}`;
+
+// Print an error and exit non-zero.
+function fail(message: string): never {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+// True when the path is an executable regular file.
+function isExecutableFile(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// Locate an executable on the caller's PATH.
+function which(name: string): string | null {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (dir && isExecutableFile(path.join(dir, name))) return path.join(dir, name);
+  }
+  return null;
+}
+
+// Escape a value for embedding in plist XML.
+function xmlEscape(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Run launchctl; by default a failure is fatal.
+function launchctl(args: string[], { ignoreFailure = false } = {}): string {
+  const result = spawnSync("launchctl", args, { encoding: "utf8" });
+  if (result.error) fail(`launchctl not runnable: ${result.error.message}`);
+  if (result.status !== 0 && !ignoreFailure) {
+    fail(`launchctl ${args.join(" ")} failed: ${(result.stderr ?? "").trim()}`);
+  }
+  return result.stdout ?? "";
+}
+
+function install(pkgArg?: string): void {
+  // Resolve absolute paths now: launchd agents run with a minimal PATH
+  // (/usr/bin:/bin:/usr/sbin:/sbin), so nothing from nvm/asdf/homebrew is visible.
+  // Prefer the npx sitting next to the real node binary over the PATH hit:
+  // version-manager shims (asdf/nvm) re-invoke their manager by name and can
+  // fail under launchd's minimal environment.
+  const nodeBin = process.execPath;
+  const siblingNpx = path.join(path.dirname(nodeBin), "npx");
+  const npxBin = isExecutableFile(siblingNpx) ? siblingNpx : (which("npx") ?? fail("npx not found on PATH"));
+
+  // omp binary: explicit env var wins, otherwise auto-detect from the current PATH.
+  const ompBin = process.env.OMP_WEB_OMP_BIN ?? which("omp");
+  if (process.env.OMP_WEB_OMP_BIN) {
+    try {
+      fs.accessSync(process.env.OMP_WEB_OMP_BIN, fs.constants.X_OK);
+    } catch {
+      fail(`OMP_WEB_OMP_BIN=${process.env.OMP_WEB_OMP_BIN} is not executable`);
+    }
+  } else if (!ompBin) {
+    console.warn("warning: omp binary not found; live-agent features will be unavailable (set OMP_WEB_OMP_BIN)");
+  }
+
+  // Service parameters with defaults; the positional package spec wins over env.
+  const pkg = pkgArg ?? process.env.OMP_WEB_PKG ?? "@kahme247/ompweb@latest";
+  const port = process.env.PORT ?? "30177";
+  const hostname = process.env.OMP_WEB_HOSTNAME ?? "127.0.0.1";
+  const noOpen = process.env.OMP_WEB_NO_OPEN ?? "1";
+  const password = process.env.OMP_WEB_PASSWORD;
+  // launchd does not expand `~` in environment values — resolve it now.
+  const agentDir = process.env.PI_CODING_AGENT_DIR?.replace(/^~(?=\/|$)/, HOME);
+
+  // Give the service a PATH covering npx/node, omp, and system tools (`open`
+  // for the browser). asdf/nvm shims re-invoke their manager by name, so the
+  // manager's own directory must be reachable too when present.
+  const asdfBin = which("asdf");
+  const svcPath = [
+    ...(ompBin ? [path.dirname(ompBin)] : []),
+    ...(asdfBin ? [path.dirname(asdfBin)] : []),
+    path.dirname(npxBin),
+    path.dirname(nodeBin),
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+  ].filter((dir, i, all) => all.indexOf(dir) === i).join(path.delimiter);
+
+  // Environment baked into the service; optional entries only when set.
+  const env: Record<string, string> = {
+    PATH: svcPath,
+    PORT: port,
+    OMP_WEB_HOSTNAME: hostname,
+    OMP_WEB_NO_OPEN: noOpen,
+    ...(password ? { OMP_WEB_PASSWORD: password } : {}),
+    ...(ompBin ? { OMP_WEB_OMP_BIN: ompBin } : {}),
+    ...(agentDir ? { PI_CODING_AGENT_DIR: agentDir } : {}),
+  };
+  const envXml = Object.entries(env)
+    .map(([key, value]) => `    <key>${xmlEscape(key)}</key><string>${xmlEscape(value)}</string>`)
+    .join("\n");
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(npxBin)}</string>
+    <string>--yes</string>
+    <string>${xmlEscape(pkg)}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+${envXml}
+  </dict>
+  <key>WorkingDirectory</key><string>${xmlEscape(HOME)}</string>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${xmlEscape(path.join(LOG_DIR, "ompweb.log"))}</string>
+  <key>StandardErrorPath</key><string>${xmlEscape(path.join(LOG_DIR, "ompweb.err.log"))}</string>
+</dict>
+</plist>
+`;
+
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  fs.mkdirSync(path.dirname(PLIST), { recursive: true });
+  // Password lives in the plist as plain text; keep it user-readable only.
+  fs.writeFileSync(PLIST, plist, { mode: 0o600 });
+  fs.chmodSync(PLIST, 0o600);
+
+  // Reload: bootout fails harmlessly when the agent isn't currently loaded.
+  launchctl(["bootout", `${DOMAIN}/${LABEL}`], { ignoreFailure: true });
+  launchctl(["bootstrap", DOMAIN, PLIST]);
+
+  console.log(`installed: ${PLIST}`);
+  console.log(`package:   ${pkg} (via npx --yes)`);
+  console.log(`url:       http://${hostname}:${port}`);
+  console.log(`logs:      ${path.join(LOG_DIR, "ompweb.log")}`);
+  if (password) console.log("note:      password is stored in plain text in the plist (mode 600)");
+}
+
+function uninstall(): void {
+  launchctl(["bootout", `${DOMAIN}/${LABEL}`], { ignoreFailure: true });
+  fs.rmSync(PLIST, { force: true });
+  console.log(`uninstalled: ${LABEL}`);
+}
+
+function status(): void {
+  const result = spawnSync("launchctl", ["print", `${DOMAIN}/${LABEL}`], { encoding: "utf8" });
+  if (result.status === 0) {
+    const lines = (result.stdout ?? "").split("\n").filter((line) => /\b(state|pid|last exit)\b/.test(line));
+    console.log(lines.join("\n") || (result.stdout ?? "").trim());
+    return;
+  }
+  console.log(`not loaded: ${LABEL}`);
+  process.exit(1);
+}
+
+if (process.platform !== "darwin") fail("launchd services are macOS-only");
+
+const command = process.argv[2] ?? "install";
+if (command === "install") install(process.argv[3]);
+else if (command === "uninstall") uninstall();
+else if (command === "status") status();
+else {
+  console.error("usage: ompweb-launchd [install [package-spec]|uninstall|status]");
+  process.exit(2);
+}


### PR DESCRIPTION
## Summary

- add an `ompweb-launchd` CLI that installs, inspects, and removes a macOS LaunchAgent
- launch ompweb through a shim-safe real `npx` path, with configurable package spec and environment
- default service installs to loopback, disable browser auto-open, keep the service alive, and write logs under `~/Library/Logs/ompweb`
- publish the installer through the npm `bin`/`files` metadata and document npx usage

## Unrelated fixes surfaced by verification

The full existing test suite exposed cross-platform filesystem and lint issues unrelated to the launchd installer. This PR fixes them rather than leaving verification red or warning:

- return canonical native realpaths for non-git project directories, including macOS `/var` aliases and Windows 8.3 paths
- support case-only agent renames on case-insensitive APFS while preserving the final filename casing
- reject renames onto a distinct hardlink entry, with regression coverage proving no partial write or displaced-file residue
- replace the existing login form's internal `window.location.assign` navigation with the Next App Router

## Verification

- rebased onto current `upstream/main`; final commit is a descendant of upstream HEAD
- latest completed CodeRabbit review against `upstream/main`: 0 findings; a final warning-cleanup recheck was rate-limited
- `npm test`: 510 tests, 509 passed, 1 skipped, 0 failed
- `node_modules/.bin/tsc --noEmit`: passed
- `npm run lint`: passed with 0 warnings
- `npm pack --dry-run --ignore-scripts`: includes `scripts/macos-launchd.mts`
- live macOS smoke test: LaunchAgent reached `state = running`, `GET http://127.0.0.1:30177/` returned HTTP 200, then uninstall removed the job/plist and closed the port
