### PR TITLE
fix: forward ompweb-launchd subcommand from main bin

### DIFF
--- a/bin/omp-web.js
+++ b/bin/omp-web.js
@@ -9,6 +9,17 @@ if (!isNodeVersionSupported(process.versions.node)) {
   process.exit(1);
 }
 
+// Forward `ompweb ompweb-launchd [args]` → bin/omp-web-launchd.js so that
+// `npx @kahme247/ompweb@latest ompweb-launchd install` works without `-p`.
+if (process.argv[2] === "ompweb-launchd" || process.argv[2] === "launchd") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { spawnSync } = require("node:child_process");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join } = require("node:path");
+  const { status } = spawnSync(process.execPath, [join(__dirname, "omp-web-launchd.js"), ...process.argv.slice(3)], { stdio: "inherit" });
+  process.exit(status ?? 1);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { spawn } = require("node:child_process");
 // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Problem

`npx --yes @kahme247/ompweb@latest ompweb-launchd install` runs the default `ompweb` bin (`bin/omp-web.js`), not `ompweb-launchd`. `parseLaunchOptions` uses `strict: false` and silently swallows the unknown positional — the web server starts instead of the launchd installer.

Same issue with `OMP_WEB_PASSWORD=secret npx --yes @kahme247/ompweb@latest ompweb-launchd` (the documented README command).

## Fix

Added an early `process.argv[2]` check in `bin/omp-web.js`: when the first arg is `ompweb-launchd` or `launchd`, it `spawnSync`s `bin/omp-web-launchd.js` with the remaining args and exits with its status code. The check runs before any heavy imports so there's no overhead.

Both forms now work:
- `npx --yes @kahme247/ompweb@latest ompweb-launchd install`
- `ompweb launchd status`

## Testing

- `node bin/omp-web.js ompweb-launchd status` → correctly reports launchd state
- `node bin/omp-web.js launchd status` → same
- `node bin/omp-web.js ompweb-launchd --bogus` → shows launchd usage error
- All 16 existing bin tests pass