### PR TITLE
feat(linux): systemd service manager + StatusNotifierItem system tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ ompweb --no-open                           # Don't auto-open the browser
 ompweb --install-tray                      # Install Windows System Tray service & Desktop shortcuts
 ompweb --uninstall-tray                    # Uninstall Windows System Tray service & shortcuts
 ompweb --tray                              # Start background System Tray manager
+ompweb systemd install                     # Install Linux systemd user service
 ompweb --help                              # Show help
 ompweb --version                           # Show version
 ```
@@ -112,6 +113,50 @@ Logs go to `~/Library/Logs/ompweb/ompweb.log` and the plist lives at
 `~/Library/LaunchAgents/com.kahme247.ompweb.plist` (mode 600; a configured
 password is stored there in plain text).
 
+### Run as a Linux Service (systemd)
+
+Install ompweb as a systemd **user** service that starts at login and restarts
+on crash:
+
+```bash
+npx --yes @kahme247/ompweb@latest ompweb-systemd install
+```
+
+Manage it with:
+
+```bash
+npx --yes @kahme247/ompweb@latest ompweb-systemd status    # Show service state
+npx --yes @kahme247/ompweb@latest ompweb-systemd restart   # start / stop / restart
+npx --yes @kahme247/ompweb@latest ompweb-systemd uninstall # Stop and remove
+```
+
+The service runs the locally installed `ompweb` binary resolved at install time
+(override with `OMP_WEB_SYSTEMD_BIN`). All
+[environment variables](#environment-variables) are read at install time and
+baked into the unit. As a service, the browser is **not** auto-opened by
+default. The unit lives at `~/.config/systemd/user/ompweb.service` (mode 600; a
+configured password is stored there in plain text) and logs go to the journal:
+
+```bash
+journalctl --user -u ompweb -f
+```
+
+### Linux System Tray (KDE Plasma and compatible)
+
+On Linux, `ompweb-tray` registers a StatusNotifierItem tray icon with a context
+menu: open the web UI, copy its URL, start/stop/restart the systemd service,
+view logs, toggle autostart, and quit the tray.
+
+```bash
+npx --yes @kahme247/ompweb@latest ompweb-tray --install      # Icons + autostart + start tray
+npx --yes @kahme247/ompweb@latest ompweb-tray --status       # Tray and service status
+npx --yes @kahme247/ompweb@latest ompweb-tray --uninstall    # Remove autostart, stop tray
+```
+
+"Start with Plasma" in the tray menu toggles a desktop autostart entry at
+`~/.config/autostart/ompweb-tray.desktop`. Requires a running StatusNotifierItem
+host (KDE Plasma, and most Wayland/X11 desktops).
+
 ## Features
 
 - **Interactive Chat**: Real-time streaming conversation with your local `omp` agent — tool calls, thinking levels, token counts, cost, context gauge, queue controls, and interrupt & retry.
@@ -123,6 +168,7 @@ password is stored there in plain text).
 - **Usage & Analytics**: Dashboard in **Settings → Usage** for tokens, costs, cache savings, and breakdowns by provider / model / day / project with SQLite persistence.
 - **Windows System Tray & Service**: Background service, tray icon, logon autostart, and Desktop/Start Menu shortcuts (Windows).
 - **macOS launchd Service**: LaunchAgent that starts at login, restarts on crash, and logs under `~/Library/Logs/ompweb`.
+- **Linux systemd Service & Tray**: User service that starts at login and restarts on crash, plus a StatusNotifierItem tray icon with service controls (KDE Plasma and compatible desktops).
 - **Web-based Settings** (8 tabs): Interface & Behavior, Safety & Approvals, AI Model Defaults, API Keys & Providers, Usage, Agent & Intelligence (advisor, memory, compaction), Agents, Extensions & Tools (MCP, skills, plugins), System & Updates.
 - **Slash Commands & Shortcuts**: Quick prompts (`/plan`, `/review`, `/fix`, `/test`, etc.), `⌘K` / `Ctrl+K` palette, and model/reasoning cycling.
 - **UI Themes & Localization**: Warm paper light/dark themes, chat font size & interface scale, with full English, Chinese (简体中文), and Japanese (日本語) translations.

--- a/bin/linux-tray.js
+++ b/bin/linux-tray.js
@@ -1,0 +1,1030 @@
+"use strict";
+
+// Linux system tray for ompweb (KDE Plasma and any StatusNotifierItem host).
+//
+// Registers a StatusNotifierItem on the session bus with a DBusMenu context
+// menu mirroring the Windows tray: open, copy URL, start/stop/restart the
+// systemd user service, view logs, autostart toggle, quit.
+//
+// CLI:
+//   ompweb-tray --install [--no-autostart]   install icons/autostart, start tray
+//   ompweb-tray --uninstall                  remove autostart and stop the tray
+//   ompweb-tray --start                      run the tray (foreground)
+//   ompweb-tray --stop | --restart           stop/restart a running tray
+//   ompweb-tray --status [--json]            tray + service status
+//   ompweb-tray --open                       open the web UI in the browser
+//   -p, --port / -H, --hostname              override status endpoint
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const dbus = require("dbus-next");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { parseArgs } = require("util");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { spawn, spawnSync } = require("node:child_process");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require("node:fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const net = require("node:net");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const os = require("node:os");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("node:path");
+
+const { Interface } = dbus.interface;
+const { Variant } = dbus;
+
+const BUS_NAME = "org.kde.ompweb.tray";
+const ITEM_PATH = "/StatusNotifierItem";
+const MENU_PATH = "/MenuBar";
+const TRAY_PATH = "/ompweb/tray";
+const SERVICE_UNIT = "ompweb.service";
+const AUTOSTART_FILE = path.join(os.homedir(), ".config", "autostart", "ompweb-tray.desktop");
+const ICON_DIR = path.join(os.homedir(), ".local", "share", "icons", "hicolor", "scalable", "apps");
+const POLL_INTERVAL_MS = 5000;
+
+// Warm-palette tray icons; installed into the user hicolor icon dir.
+const ICON_RUNNING = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#c96f4a"/>
+  <path d="M18 22 L30 32 L18 42" fill="none" stroke="#fff8f2" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="34" y="38" width="14" height="6" rx="3" fill="#fff8f2"/>
+</svg>
+`;
+const ICON_STOPPED = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#8d8578"/>
+  <rect x="20" y="28" width="24" height="8" rx="4" fill="#f5f1ea"/>
+</svg>
+`;
+
+// ---------------------------------------------------------------------------
+// Pure-JS tray icon rasterizer (SNI IconPixmap, ARGB32 big-endian = [A,R,G,B])
+//
+// Matches the SVG design: rounded square + prompt chevron + underscore
+// (running) / gray square + flat bar (stopped). Rasterized at process start so
+// the panel icon renders even when the theme cannot resolve IconName.
+// ---------------------------------------------------------------------------
+
+const TRAY_COLORS = {
+  running: { bg: [201, 111, 74], fg: [255, 248, 242] }, // #c96f4a / #fff8f2
+  stopped: { bg: [141, 133, 120], fg: [245, 241, 234] }, // #8d8578 / #f5f1ea
+};
+
+const TRAY_ICON_PIXMAP_SIZES = [24, 32, 64];
+
+const clamp01 = (v) => Math.min(1, Math.max(0, v));
+
+// Signed distance to a rounded box centered at (cx, cy) with half extents.
+function sdRoundRect(px, py, cx, cy, hx, hy, r) {
+  const qx = Math.abs(px - cx) - (hx - r);
+  const qy = Math.abs(py - cy) - (hy - r);
+  const ox = Math.max(qx, 0);
+  const oy = Math.max(qy, 0);
+  return Math.hypot(ox, oy) + Math.min(Math.max(qx, qy), 0) - r;
+}
+
+// Signed distance to a segment (round caps) — used for the chevron strokes.
+function sdSegment(px, py, ax, ay, bx, by) {
+  const abx = bx - ax;
+  const aby = by - ay;
+  const apx = px - ax;
+  const apy = py - ay;
+  const t = clamp01((apx * abx + apy * aby) / (abx * abx + aby * aby));
+  return Math.hypot(apx - abx * t, apy - aby * t);
+}
+
+// Signed distance for the foreground glyph at design coordinates (0..64).
+function foregroundDistance(px, py, running) {
+  if (!running) {
+    // Flat horizontal bar: rounded rect centered (32, 32), half (12, 4), r 4.
+    return sdRoundRect(px, py, 32, 32, 12, 4, 4);
+  }
+  const chevron = Math.min(
+    sdSegment(px, py, 18, 22, 30, 32),
+    sdSegment(px, py, 30, 32, 18, 42),
+  ) - 3; // 6px stroke → half-width 3
+  const underscore = sdRoundRect(px, py, 41, 41, 7, 3, 3);
+  return Math.min(chevron, underscore);
+}
+
+// Convert one design pixel (SDF coverage) into straight-alpha ARGB floats.
+function shadePixel(designX, designY, running, colors) {
+  // 2×2 supersampling against the background rounded box and the glyph.
+  let bgCover = 0;
+  let fgCover = 0;
+  for (const [ox, oy] of [[0.25, 0.25], [0.75, 0.25], [0.25, 0.75], [0.75, 0.75]]) {
+    const x = designX + ox;
+    const y = designY + oy;
+    bgCover += clamp01(0.5 - sdRoundRect(x, y, 32, 32, 28, 28, 14));
+    fgCover += clamp01(0.5 - foregroundDistance(x, y, running));
+  }
+  const bgA = bgCover / 4;
+  const fgA = fgCover / 4;
+  // Composite foreground over background over transparent.
+  const outA = fgA + bgA * (1 - fgA);
+  if (outA <= 0) return [0, 0, 0, 0];
+  const mix = (f, b) => (f * fgA + b * bgA * (1 - fgA)) / outA;
+  return [outA, mix(colors.fg[0], colors.bg[0]), mix(colors.fg[1], colors.bg[1]), mix(colors.fg[2], colors.bg[2])];
+}
+
+// Rasterize the tray icon; returns an ARGB32 byte buffer ([A,R,G,B] per pixel).
+function buildTrayIconPixels(size, running) {
+  const colors = TRAY_COLORS[running ? "running" : "stopped"];
+  const scale = size / 64;
+  const buffer = Buffer.alloc(size * size * 4);
+  let offset = 0;
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const [a, r, g, b] = shadePixel((x + 0.5) / scale, (y + 0.5) / scale, running, colors);
+      buffer[offset] = Math.round(a * 255);
+      buffer[offset + 1] = Math.round(r);
+      buffer[offset + 2] = Math.round(g);
+      buffer[offset + 3] = Math.round(b);
+      offset += 4;
+    }
+  }
+  return buffer;
+}
+
+// SNI IconPixmap value: array of (width, height, ARGB32 bytes) structs.
+function buildIconPixmap(running) {
+  return TRAY_ICON_PIXMAP_SIZES.map((size) => [size, size, buildTrayIconPixels(size, running)]);
+}
+
+function printHelp() {
+  console.log(`Usage: ompweb-tray [command] [options]
+
+Linux system tray icon (StatusNotifierItem) for the ompweb web service.
+
+Commands:
+  --install, install     Install icons + autostart entry, then start the tray
+  --uninstall, uninstall Remove autostart entry and stop the tray
+  --start, start         Run the tray (foreground)
+  --stop, stop           Stop a running tray
+  --restart, restart     Restart the tray
+  --status, status       Show tray and service status (default)
+  --open, open           Open the web service in the default browser
+
+Options:
+  -p, --port <port>       Service port used for status (default from config)
+  -H, --hostname <host>   Service hostname used for status (default from config)
+      --no-autostart      Install without the desktop autostart entry
+      --json              Output status as JSON
+  -h, --help              Show this help
+  -v, --version           Show version
+`);
+}
+
+function readPackageVersion() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("../package.json").version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+function sanitizePort(val, fallback = 30177) {
+  const port = parseInt(val, 10);
+  return Number.isInteger(port) && port >= 0 && port <= 65535 ? port : fallback;
+}
+
+function sanitizeHostname(val, fallback = "127.0.0.1") {
+  if (typeof val !== "string" || !val.trim()) return fallback;
+  return val.trim();
+}
+
+// Tray configuration: CLI overrides win, then ~/.omp/agent/web-service.json.
+function readTrayConfig(overrides = {}, env = process.env, home = os.homedir()) {
+  const agentDir = (env.PI_CODING_AGENT_DIR ?? path.join(home, ".omp", "agent")).replace(/^~(?=\/|$)/, home);
+  const configFile = path.join(agentDir, "web-service.json");
+  let fileConfig = {};
+  try {
+    fileConfig = JSON.parse(fs.readFileSync(configFile, "utf8"));
+  } catch {
+    fileConfig = {};
+  }
+  const port = overrides.port ?? sanitizePort(fileConfig.port);
+  const hostname = overrides.hostname ?? sanitizeHostname(fileConfig.hostname);
+  return { port, hostname, configFile, serviceUrl: `http://${hostname}:${port}` };
+}
+
+// Menu item table. `separator` items render as dividers; `checkmark` items
+// carry a toggle state; `disabled` items are inert status rows.
+function buildMenuItems({ running, version, autostart, hasService }) {
+  return [
+    { id: 1, label: `ompweb (v${version})`, enabled: false },
+    { id: 2, label: running ? "  Status: Running" : "  Status: Stopped", enabled: false },
+    { id: 3, separator: true },
+    { id: 4, label: "Open in Browser", action: "open" },
+    { id: 5, label: "Copy Web URL", action: "copy" },
+    { id: 6, separator: true },
+    { id: 7, label: running ? "Stop Server" : "Start Server", action: "toggle", enabled: hasService },
+    { id: 8, label: "Restart Server", action: "restart", enabled: hasService },
+    { id: 9, separator: true },
+    { id: 10, label: "View Logs", action: "logs" },
+    { id: 11, label: "Start with Plasma", action: "autostart", checkmark: true, state: autostart ? 1 : 0 },
+    { id: 12, separator: true },
+    { id: 13, label: "Quit Tray", action: "quit" },
+  ];
+}
+
+// DBus {sv} dictionary for one menu item.
+function itemProperties(item) {
+  if (item.separator) {
+    return {
+      type: new Variant("s", "separator"),
+      visible: new Variant("b", true),
+    };
+  }
+  const props = {
+    label: new Variant("s", item.label),
+    enabled: new Variant("b", item.enabled !== false),
+    visible: new Variant("b", true),
+  };
+  if (item.checkmark) {
+    props["toggle-type"] = new Variant("s", "checkmark");
+    props["toggle-state"] = new Variant("i", item.state ?? 0);
+  }
+  return props;
+}
+
+// (ia{sv}av) struct for one menu node; children wrapped in variants.
+function layoutNode(id, props, children = []) {
+  return [id, props, children.map((child) => new Variant("(ia{sv}av)", child))];
+}
+
+// Full GetLayout response for the flat tray menu.
+function buildLayout(items, revision, parentId = 0) {
+  if (parentId === 0) {
+    const children = items.map((item) => layoutNode(item.id, itemProperties(item), []));
+    return [revision, layoutNode(0, { "children-display": new Variant("s", "submenu") }, children)];
+  }
+  const item = items.find((entry) => entry.id === parentId);
+  if (!item) return [revision, layoutNode(parentId, {}, [])];
+  return [revision, layoutNode(item.id, itemProperties(item), [])];
+}
+
+// [revision, layout] is cached; tests assert structure without dbus objects.
+function itemById(items, id) {
+  return items.find((entry) => entry.id === id) ?? null;
+}
+
+function buildAutostartDesktop(execLine) {
+  return [
+    "[Desktop Entry]",
+    "Type=Application",
+    "Name=ompweb Tray",
+    "GenericName=ompweb tray icon",
+    "Comment=ompweb web service tray icon and controls",
+    `Exec=${execLine}`,
+    "Icon=ompweb",
+    "Terminal=false",
+    "Categories=Network;",
+    "X-GNOME-Autostart-enabled=true",
+    "X-KDE-autostart-after=panel",
+    "",
+  ].join("\n");
+}
+
+function buildAutostartExec() {
+  const nodeBin = process.execPath;
+  const script = path.resolve(__filename);
+  const needsQuoting = [nodeBin, script].some((part) => /\s/.test(part));
+  if (!needsQuoting) return `${nodeBin} ${script} --start`;
+  return `"${nodeBin.replace(/"/g, '\\"')}" "${script.replace(/"/g, '\\"')}" --start`;
+}
+
+// Terminal used to open logs; ordered candidates, first hit wins.
+function terminalCandidates(env = process.env) {
+  return [
+    ...(env.OMP_WEB_TERMINAL ? [env.OMP_WEB_TERMINAL] : []),
+    ...(env.TERMINAL ? [env.TERMINAL] : []),
+    "konsole",
+    "alacritty",
+    "kitty",
+    "gnome-terminal",
+    "xterm",
+  ];
+}
+
+// Prefix args for running a command inside the given terminal.
+function terminalPrefix(terminal) {
+  if (terminal === "gnome-terminal") return [terminal, "--"];
+  return [terminal, "-e"];
+}
+
+function isExecutable(candidate) {
+  try {
+    return fs.statSync(candidate).isFile() && fs.accessSync(candidate, fs.constants.X_OK) === undefined;
+  } catch {
+    return false;
+  }
+}
+
+function which(name) {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (dir && isExecutable(path.join(dir, name))) return path.join(dir, name);
+  }
+  return null;
+}
+
+function resolveTerminal(env = process.env) {
+  for (const candidate of terminalCandidates(env)) {
+    const base = path.basename(candidate);
+    if (candidate.includes(path.sep) && isExecutable(candidate)) return candidate;
+    if (!candidate.includes(path.sep) && which(base)) return base;
+  }
+  return null;
+}
+
+function resolveClipboardBin() {
+  return which("wl-copy") ?? which("xclip") ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Async helpers
+// ---------------------------------------------------------------------------
+
+// Resolve via TCP connect; server presence is what "running" means for the tray.
+function probeServer(hostname, port, timeoutMs = 1200) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (result) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    const socket = new net.Socket();
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+    socket.connect(port, hostname);
+  });
+}
+
+function systemctlUser(args) {
+  const result = spawnSync("systemctl", ["--user", ...args], { encoding: "utf8" });
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
+function serviceInstalled() {
+  const dir = process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config");
+  return fs.existsSync(path.join(dir, "systemd", "user", SERVICE_UNIT));
+}
+
+function openUrl(url) {
+  const openBin = which("xdg-open") ?? "xdg-open";
+  const child = spawn(openBin, [url], { stdio: "ignore", detached: true });
+  child.on("error", () => {});
+  child.unref();
+}
+
+function copyToClipboard(text) {
+  const bin = resolveClipboardBin();
+  if (!bin) return false;
+  const args = path.basename(bin) === "xclip" ? ["-selection", "clipboard"] : [];
+  const result = spawnSync(bin, args, { input: text, encoding: "utf8" });
+  return !result.error && result.status === 0;
+}
+
+function viewLogs() {
+  const terminal = resolveTerminal();
+  if (!terminal) return false;
+  const resolved = candidateBinPath(terminal);
+  if (!resolved) return false;
+  const prefix = terminalPrefix(terminal).slice(1);
+  const child = spawn(resolved, [...prefix, `journalctl --user -u ompweb -f`], {
+    stdio: "ignore",
+    detached: true,
+    env: process.env,
+  });
+  child.on("error", () => {});
+  child.unref();
+  return true;
+}
+
+function candidateBinPath(terminal) {
+  if (terminal.includes(path.sep)) return terminal;
+  return which(path.basename(terminal)) ?? terminal;
+}
+
+// ---------------------------------------------------------------------------
+// DBus interfaces
+// ---------------------------------------------------------------------------
+
+class StatusNotifierItem extends Interface {
+  constructor(state) {
+    super("org.kde.StatusNotifierItem");
+    this.state = state;
+  }
+
+  get Status() {
+    return "Active";
+  }
+
+  // IconName stays empty on purpose: Plasma prefers the theme name when
+  // non-empty and renders an unresolvable name as nothing. Shipping real
+  // ARGB pixels (IconPixmap) renders deterministically on every host.
+  get IconName() {
+    return "";
+  }
+
+  get IconPixmap() {
+    return buildIconPixmap(this.state.running);
+  }
+
+  get ToolTip() {
+    return [
+      "",
+      this.state.running ? buildIconPixmap(true) : buildIconPixmap(false),
+      "ompweb",
+      this.state.running ? `Running — ${this.state.serviceUrl}` : "Service stopped",
+    ];
+  }
+
+  Activate() {
+    openUrl(this.state.serviceUrl);
+  }
+
+  SecondaryActivate() {
+    openUrl(this.state.serviceUrl);
+  }
+
+  Scroll() {}
+
+  // Signal emitters — dbus-next emits the returned value as the signal body.
+  NewTitle(...args) { return args; }
+  NewIcon(...args) { return args; }
+  NewAttentionIcon(...args) { return args; }
+  NewOverlayIcon(...args) { return args; }
+  NewToolTip(...args) { return args; }
+  NewStatus(...args) { return args; }
+}
+
+StatusNotifierItem.configureMembers({
+  properties: {
+    Category: { signature: "s", access: "read" },
+    Id: { signature: "s", access: "read" },
+    Title: { signature: "s", access: "read" },
+    Status: { signature: "s", access: "read" },
+    WindowId: { signature: "i", access: "read" },
+    IconName: { signature: "s", access: "read" },
+    // KDE marshals tray pixmaps as (width, height, ARGB32 byte array).
+    IconPixmap: { signature: "a(iiay)", access: "read" },
+    AttentionIconName: { signature: "s", access: "read" },
+    AttentionIconPixmap: { signature: "a(iiay)", access: "read" },
+    OverlayIconName: { signature: "s", access: "read" },
+    OverlayIconPixmap: { signature: "a(iiay)", access: "read" },
+    ToolTip: { signature: "(sa(iiay)ss)", access: "read" },
+    Menu: { signature: "o", access: "read" },
+    ItemIsMenu: { signature: "b", access: "read" },
+  },
+  methods: {
+    Activate: { inSignature: "ii", outSignature: "" },
+    SecondaryActivate: { inSignature: "ii", outSignature: "" },
+    Scroll: { inSignature: "is", outSignature: "" },
+  },
+  signals: {
+    NewTitle: { signature: "" },
+    NewIcon: { signature: "" },
+    NewAttentionIcon: { signature: "" },
+    NewOverlayIcon: { signature: "" },
+    NewToolTip: { signature: "" },
+    NewStatus: { signature: "s" },
+  },
+});
+
+StatusNotifierItem.prototype.Category = "ApplicationStatus";
+StatusNotifierItem.prototype.Id = "ompweb";
+StatusNotifierItem.prototype.Title = "ompweb";
+// Status, IconName, IconPixmap, and ToolTip stay as class getters (dynamic).
+StatusNotifierItem.prototype.WindowId = 0;
+StatusNotifierItem.prototype.AttentionIconName = "";
+StatusNotifierItem.prototype.AttentionIconPixmap = [];
+StatusNotifierItem.prototype.OverlayIconName = "";
+StatusNotifierItem.prototype.OverlayIconPixmap = [];
+StatusNotifierItem.prototype.ItemIsMenu = true;
+StatusNotifierItem.prototype.Menu = MENU_PATH;
+
+class DbusMenu extends Interface {
+  constructor(state) {
+    super("com.canonical.dbusmenu");
+    this.state = state;
+  }
+
+  GetLayout(parentId) {
+    return buildLayout(this.state.menuItems(), this.state.menuRevision, Number(parentId) || 0);
+  }
+
+  GetGroupProperties(ids) {
+    const items = this.state.menuItems();
+    const found = ids
+      .map((id) => itemById(items, Number(id)))
+      .filter(Boolean)
+      .map((item) => [item.id, itemProperties(item)]);
+    return [found, []];
+  }
+
+  AboutToShow() {
+    return false;
+  }
+
+  Event(id, event) {
+    this.state.handleEvent(Number(id), event);
+  }
+
+  EventGroup(events) {
+    for (const entry of events ?? []) {
+      const [id, event] = entry;
+      this.state.handleEvent(Number(id), String(event));
+    }
+    return [[]];
+  }
+
+  // Signal emitters — dbus-next emits the returned value as the signal body.
+  LayoutUpdated(...args) { return args; }
+  ItemsPropertiesUpdated(...args) { return args; }
+}
+
+DbusMenu.configureMembers({
+  properties: {
+    Version: { signature: "u", access: "read" },
+    TextDirection: { signature: "s", access: "read" },
+    Status: { signature: "s", access: "read" },
+    IconThemePath: { signature: "s", access: "read" },
+  },
+  methods: {
+    GetLayout: { inSignature: "iias", outSignature: "u(ia{sv}av)" },
+    GetGroupProperties: { inSignature: "aias", outSignature: "a(ia{sv})as" },
+    AboutToShow: { inSignature: "i", outSignature: "b" },
+    Event: { inSignature: "isvu", outSignature: "" },
+    EventGroup: { inSignature: "a(isvu)", outSignature: "ab" },
+  },
+  signals: {
+    LayoutUpdated: { signature: "ui" },
+    ItemsPropertiesUpdated: { signature: "a(ia{sv})a(ia{sv})" },
+  },
+});
+
+DbusMenu.prototype.Version = 3;
+DbusMenu.prototype.TextDirection = "ltr";
+DbusMenu.prototype.Status = "normal";
+DbusMenu.prototype.IconThemePath = "";
+
+class TrayControl extends Interface {
+  constructor(state) {
+    super("org.kde.ompweb.Tray");
+    this.state = state;
+  }
+
+  Quit() {
+    this.state.quit();
+  }
+}
+
+TrayControl.configureMembers({
+  methods: {
+    Quit: { inSignature: "", outSignature: "" },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tray state machine
+// ---------------------------------------------------------------------------
+
+function createTrayState(config, { log = console.log } = {}) {
+  const state = {
+    running: false,
+    autostart: fs.existsSync(AUTOSTART_FILE),
+    hasService: serviceInstalled(),
+    menuRevision: 1,
+    bus: null,
+    sni: null,
+    menu: null,
+    pollTimer: null,
+    registerTimer: null,
+    registered: false,
+    quitting: false,
+    serviceUrl: config.serviceUrl,
+    port: config.port,
+    hostname: config.hostname,
+    version: readPackageVersion(),
+  };
+
+  state.menuItems = () =>
+    buildMenuItems({
+      running: state.running,
+      version: state.version,
+      autostart: state.autostart,
+      hasService: state.hasService,
+    });
+
+  state.refreshMenu = () => {
+    state.menuRevision += 1;
+    if (state.menu) state.menu.LayoutUpdated(state.menuRevision, 0);
+  };
+
+  state.refreshIcon = () => {
+    if (!state.sni) return;
+    Interface.emitPropertiesChanged(state.sni, {
+      IconName: "",
+      IconPixmap: buildIconPixmap(state.running),
+      ToolTip: ["", buildIconPixmap(state.running), "ompweb", state.running ? `Running — ${state.serviceUrl}` : "Service stopped"],
+    });
+    state.sni.NewIcon();
+    state.sni.NewToolTip();
+  };
+
+  state.handleEvent = (id, event) => {
+    if (event !== "clicked") return;
+    const item = itemById(state.menuItems(), id);
+    if (!item || item.enabled === false) return;
+    switch (item.action) {
+      case "open":
+        openUrl(state.serviceUrl);
+        break;
+      case "copy":
+        if (!copyToClipboard(state.serviceUrl)) state.notify("ompweb", "No clipboard tool found (install wl-clipboard)");
+        break;
+      case "toggle":
+        systemctlUser([state.running ? "stop" : "start", SERVICE_UNIT]);
+        break;
+      case "restart":
+        systemctlUser(["restart", SERVICE_UNIT]);
+        break;
+      case "logs":
+        if (!viewLogs()) state.notify("ompweb", "No terminal emulator found for logs");
+        break;
+      case "autostart":
+        state.setAutostart(!state.autostart);
+        break;
+      case "quit":
+        state.quit();
+        break;
+      default:
+        break;
+    }
+  };
+
+  state.setAutostart = (enable) => {
+    try {
+      if (enable) {
+        fs.mkdirSync(path.dirname(AUTOSTART_FILE), { recursive: true });
+        fs.writeFileSync(AUTOSTART_FILE, buildAutostartDesktop(buildAutostartExec()), { mode: 0o644 });
+      } else {
+        fs.rmSync(AUTOSTART_FILE, { force: true });
+      }
+      state.autostart = enable;
+      state.refreshMenu();
+    } catch (err) {
+      state.notify("ompweb", `Autostart update failed: ${err.message}`);
+    }
+  };
+
+  state.notify = async (summary, body) => {
+    if (!state.bus) return;
+    try {
+      const obj = await state.bus.getProxyObject("org.freedesktop.Notifications", "/org/freedesktop/Notifications");
+      const iface = obj.getInterface("org.freedesktop.Notifications");
+      await iface.Notify("ompweb", 0, "ompweb", summary, body, [], {}, 5000);
+    } catch {
+      // Notifications are best-effort.
+    }
+  };
+
+  state.poll = async () => {
+    const wasRunning = state.running;
+    let running = false;
+    try {
+      running = await probeServer(state.hostname, state.port);
+    } catch {
+      running = false;
+    }
+    const hadService = state.hasService;
+    state.hasService = serviceInstalled();
+    if (running !== wasRunning) {
+      state.running = running;
+      state.refreshIcon();
+      state.refreshMenu();
+    } else if (state.hasService !== hadService) {
+      state.refreshMenu();
+    }
+  };
+
+  state.registerWithWatcher = async () => {
+    if (!state.bus) return;
+    try {
+      const obj = await state.bus.getProxyObject("org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher");
+      const watcher = obj.getInterface("org.kde.StatusNotifierWatcher");
+      // KDE's watcher expects the bare bus name; /StatusNotifierItem is assumed.
+      // Re-registration is idempotent (the watcher dedupes), so this also
+      // self-heals after a plasmashell/kded6 restart.
+      await watcher.RegisterStatusNotifierItem(BUS_NAME);
+      if (!state.registered) log("tray registered with StatusNotifierWatcher");
+      state.registered = true;
+    } catch {
+      // Watcher (plasmashell) may not be up yet; retry via timer.
+    }
+  };
+
+  state.quit = () => {
+    if (state.quitting) return;
+    state.quitting = true;
+    clearInterval(state.pollTimer);
+    clearInterval(state.registerTimer);
+    try {
+      if (state.bus) state.bus.disconnect();
+    } catch {
+      // Ignore disconnect errors on shutdown.
+    }
+    process.exit(0);
+  };
+
+  return state;
+}
+
+async function startTray(config, { log = console.log, error = console.error } = {}) {
+  const state = createTrayState(config, { log });
+
+  installIcons({ log });
+  ensureIconThemeCache();
+
+  const bus = dbus.sessionBus();
+  state.bus = bus;
+
+  let nameReply;
+  try {
+    nameReply = await bus.requestName(BUS_NAME, 0);
+  } catch (err) {
+    error(`failed to request bus name: ${err.message}`);
+    process.exit(1);
+  }
+  // 1 = primary owner, 4 = already ours; anything else means another tray runs.
+  if (nameReply !== 1 && nameReply !== 4) {
+    log("ompweb tray is already running");
+    return state;
+  }
+
+  const sni = new StatusNotifierItem(state);
+  const menu = new DbusMenu(state);
+  const control = new TrayControl(state);
+  state.sni = sni;
+  state.menu = menu;
+
+  bus.export(ITEM_PATH, sni);
+  bus.export(MENU_PATH, menu);
+  bus.export(TRAY_PATH, control);
+
+  bus.on("error", (err) => error(`session bus error: ${err.message}`));
+
+  await state.poll();
+  await state.registerWithWatcher();
+  state.registerTimer = setInterval(() => state.registerWithWatcher(), 60000);
+  state.pollTimer = setInterval(() => state.poll(), POLL_INTERVAL_MS);
+  log(`ompweb tray started (${state.serviceUrl})`);
+  return state;
+}
+
+function installIcons({ log = console.log } = {}) {
+  try {
+    fs.mkdirSync(ICON_DIR, { recursive: true });
+    fs.writeFileSync(path.join(ICON_DIR, "ompweb.svg"), ICON_RUNNING, { mode: 0o644 });
+    fs.writeFileSync(path.join(ICON_DIR, "ompweb-off.svg"), ICON_STOPPED, { mode: 0o644 });
+  } catch (err) {
+    log(`warning: could not install tray icons: ${err.message}`);
+  }
+}
+
+// Best-effort cache refresh so plasmashell picks up freshly written icons.
+function ensureIconThemeCache() {
+  for (const tool of ["kbuildsycoca6", "kbuildsycoca5", "gtk-update-icon-cache"]) {
+    const bin = which(tool);
+    if (!bin) continue;
+    const args = tool.startsWith("gtk-update-icon-cache") ? ["-f", "-t", path.join(ICON_DIR, "..", "..", "..") ] : [];
+    try {
+      spawnSync(bin, args, { stdio: "ignore", timeout: 10000 });
+    } catch {
+      // Ignore cache refresh failures.
+    }
+    break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function getTrayRunning(bus) {
+  try {
+    const dbusObj = await bus.getProxyObject("org.freedesktop.DBus", "/org/freedesktop/DBus");
+    const dbusIface = dbusObj.getInterface("org.freedesktop.DBus");
+    await dbusIface.GetNameOwner(BUS_NAME);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function quitRunningTray() {
+  const bus = dbus.sessionBus();
+  try {
+    const obj = await bus.getProxyObject(BUS_NAME, TRAY_PATH);
+    const iface = obj.getInterface("org.kde.ompweb.Tray");
+    await iface.Quit();
+    return true;
+  } catch {
+    return false;
+  } finally {
+    bus.disconnect();
+  }
+}
+
+async function readStatus(overrides) {
+  const config = readTrayConfig(overrides);
+  let trayRunning = false;
+  try {
+    const bus = dbus.sessionBus();
+    try {
+      trayRunning = await getTrayRunning(bus);
+    } finally {
+      bus.disconnect();
+    }
+  } catch {
+    // No session bus (CI, SSH without a GUI session): report not running.
+    trayRunning = false;
+  }
+  const active = systemctlUser(["is-active", SERVICE_UNIT.replace(/\.service$/, "")]);
+  const serviceRunning = active.ok && active.stdout === "active";
+  const autostart = fs.existsSync(AUTOSTART_FILE);
+  return {
+    isLinux: process.platform === "linux",
+    trayRunning,
+    serviceInstalled: serviceInstalled(),
+    serviceRunning,
+    autostart,
+    port: config.port,
+    hostname: config.hostname,
+    serviceUrl: config.serviceUrl,
+    configFile: config.configFile,
+    autostartFile: AUTOSTART_FILE,
+    version: readPackageVersion(),
+  };
+}
+
+function spawnDetachedTray() {
+  const child = spawn(process.execPath, [path.resolve(__filename), "--start"], {
+    stdio: "ignore",
+    detached: true,
+    env: process.env,
+  });
+  child.on("error", (err) => console.error(`failed to start tray: ${err.message}`));
+  child.unref();
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const { values: cliArgs, positionals } = parseArgs({
+    args: argv,
+    options: {
+      install:        { type: "boolean" },
+      uninstall:      { type: "boolean" },
+      start:          { type: "boolean" },
+      stop:           { type: "boolean" },
+      restart:        { type: "boolean" },
+      status:         { type: "boolean" },
+      open:           { type: "boolean" },
+      port:           { type: "string", short: "p" },
+      hostname:       { type: "string", short: "H" },
+      "no-autostart": { type: "boolean" },
+      json:           { type: "boolean" },
+      help:           { type: "boolean", short: "h" },
+      version:        { type: "boolean", short: "v" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  if (process.platform !== "linux") {
+    console.error("error: the Linux tray is only supported on Linux (see omp-web-tray for Windows)");
+    return { exitCode: 1 };
+  }
+
+  if (cliArgs.version || positionals.includes("version")) {
+    console.log(readPackageVersion());
+    return { exitCode: 0 };
+  }
+  if (cliArgs.help || positionals.includes("help")) {
+    printHelp();
+    return { exitCode: 0 };
+  }
+
+  const has = (flag) => cliArgs[flag] || positionals.includes(flag);
+  const overrides = {
+    ...(cliArgs.port ? { port: sanitizePort(cliArgs.port) } : {}),
+    ...(cliArgs.hostname ? { hostname: sanitizeHostname(cliArgs.hostname) } : {}),
+  };
+
+  if (has("install")) {
+    installIcons();
+    ensureIconThemeCache();
+    if (!cliArgs["no-autostart"]) {
+      fs.mkdirSync(path.dirname(AUTOSTART_FILE), { recursive: true });
+      fs.writeFileSync(AUTOSTART_FILE, buildAutostartDesktop(buildAutostartExec()), { mode: 0o644 });
+      console.log(`autostart installed: ${AUTOSTART_FILE}`);
+    }
+    spawnDetachedTray();
+    console.log("tray started in background.");
+    return { exitCode: 0 };
+  }
+
+  if (has("uninstall")) {
+    fs.rmSync(AUTOSTART_FILE, { force: true });
+    const stopped = await quitRunningTray();
+    console.log(`autostart removed: ${AUTOSTART_FILE}`);
+    console.log(stopped ? "tray stopped." : "tray was not running.");
+    return { exitCode: 0 };
+  }
+
+  if (has("start")) {
+    const config = readTrayConfig(overrides);
+    await startTray(config);
+    return { exitCode: 0 };
+  }
+
+  if (has("stop")) {
+    const stopped = await quitRunningTray();
+    console.log(stopped ? "tray stopped." : "tray was not running.");
+    return { exitCode: 0 };
+  }
+
+  if (has("restart")) {
+    await quitRunningTray();
+    installIcons();
+    spawnDetachedTray();
+    console.log("tray restarted in background.");
+    return { exitCode: 0 };
+  }
+
+  if (has("open")) {
+    const config = readTrayConfig(overrides);
+    openUrl(config.serviceUrl);
+    return { exitCode: 0 };
+  }
+
+  // Default: status.
+  const status = await readStatus(overrides);
+  if (cliArgs.json) {
+    console.log(JSON.stringify(status, null, 2));
+  } else {
+    console.log(`=== ompweb Linux tray status ===`);
+    console.log(`  Tray running    : ${status.trayRunning ? "Yes" : "No"}`);
+    console.log(`  Service unit    : ${status.serviceInstalled ? "installed" : "not installed"} (${status.serviceRunning ? "active" : "inactive"})`);
+    console.log(`  Autostart       : ${status.autostart ? `enabled (${status.autostartFile})` : "disabled"}`);
+    console.log(`  Live URL        : ${status.serviceUrl}`);
+  }
+  return { exitCode: 0, status };
+}
+
+if (require.main === module) {
+  runCli().then(({ exitCode }) => {
+    if (exitCode !== undefined && exitCode !== 0) process.exit(exitCode);
+  }).catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  AUTOSTART_FILE,
+  BUS_NAME,
+  ICON_RUNNING,
+  ICON_STOPPED,
+  TRAY_ICON_PIXMAP_SIZES,
+  buildAutostartDesktop,
+  buildAutostartExec,
+  buildIconPixmap,
+  buildLayout,
+  buildMenuItems,
+  buildTrayIconPixels,
+  itemById,
+  itemProperties,
+  layoutNode,
+  pollIntervalMs: POLL_INTERVAL_MS,
+  probeServer,
+  readTrayConfig,
+  resolveTerminal,
+  runCli,
+  sanitizeHostname,
+  sanitizePort,
+  serviceInstalled,
+  terminalCandidates,
+  terminalPrefix,
+};

--- a/bin/linux-tray.test.mjs
+++ b/bin/linux-tray.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  TRAY_ICON_PIXMAP_SIZES,
+  buildAutostartDesktop,
+  buildAutostartExec,
+  buildIconPixmap,
+  buildLayout,
+  buildMenuItems,
+  buildTrayIconPixels,
+  itemById,
+  itemProperties,
+  probeServer,
+  readTrayConfig,
+  sanitizeHostname,
+  sanitizePort,
+  terminalCandidates,
+  terminalPrefix,
+} = require("./linux-tray.js");
+
+test("sanitizePort accepts valid ports and falls back otherwise", () => {
+  assert.equal(sanitizePort("30177"), 30177);
+  assert.equal(sanitizePort(8080), 8080);
+  assert.equal(sanitizePort("nope"), 30177);
+  assert.equal(sanitizePort("70000"), 30177);
+  assert.equal(sanitizePort(undefined, 4000), 4000);
+});
+
+test("sanitizeHostname trims strings and rejects empties", () => {
+  assert.equal(sanitizeHostname(" 0.0.0.0 "), "0.0.0.0");
+  assert.equal(sanitizeHostname(""), "127.0.0.1");
+  assert.equal(sanitizeHostname(undefined, "localhost"), "localhost");
+});
+
+test("readTrayConfig prefers CLI overrides over the service config file", () => {
+  const home = mkdtempSync(path.join(tmpdir(), "ompweb-tray-"));
+  try {
+    const agentDir = path.join(home, ".omp", "agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(path.join(agentDir, "web-service.json"), JSON.stringify({ port: 40001, hostname: "0.0.0.0" }));
+
+    const config = readTrayConfig({}, {}, home);
+    assert.equal(config.port, 40001);
+    assert.equal(config.hostname, "0.0.0.0");
+    assert.equal(config.serviceUrl, "http://0.0.0.0:40001");
+
+    const overridden = readTrayConfig({ port: 40100, hostname: "127.0.0.1" }, {}, home);
+    assert.equal(overridden.port, 40100);
+    assert.equal(overridden.serviceUrl, "http://127.0.0.1:40100");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("readTrayConfig falls back to defaults without a config file", () => {
+  const home = mkdtempSync(path.join(tmpdir(), "ompweb-tray-"));
+  try {
+    const config = readTrayConfig({}, {}, home);
+    assert.equal(config.port, 30177);
+    assert.equal(config.hostname, "127.0.0.1");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("buildMenuItems reflects running state and service availability", () => {
+  const running = buildMenuItems({ running: true, version: "0.4.2", autostart: true, hasService: true });
+  assert.equal(itemById(running, 2).label, "  Status: Running");
+  assert.equal(itemById(running, 7).label, "Stop Server");
+  assert.equal(itemById(running, 11).state, 1);
+
+  const stoppedNoService = buildMenuItems({ running: false, version: "0.4.2", autostart: false, hasService: false });
+  assert.equal(itemById(stoppedNoService, 2).label, "  Status: Stopped");
+  assert.equal(itemById(stoppedNoService, 7).label, "Start Server");
+  assert.equal(itemById(stoppedNoService, 7).enabled, false);
+  assert.equal(itemById(stoppedNoService, 8).enabled, false);
+  assert.equal(itemById(stoppedNoService, 11).state, 0);
+
+  // Inert rows and separators.
+  assert.equal(itemById(running, 1).enabled, false);
+  assert.ok(itemById(running, 3).separator);
+});
+
+test("itemProperties renders standard, separator, and checkmark items", () => {
+  const standard = itemProperties({ id: 4, label: "Open in Browser" });
+  assert.equal(standard.label.value, "Open in Browser");
+  assert.equal(standard.enabled.value, true);
+  assert.ok(!standard["toggle-type"]);
+
+  const separator = itemProperties({ id: 6, separator: true });
+  assert.equal(separator.type.value, "separator");
+
+  const checkmark = itemProperties({ id: 11, label: "Start with Plasma", checkmark: true, state: 1 });
+  assert.equal(checkmark["toggle-type"].value, "checkmark");
+  assert.equal(checkmark["toggle-state"].value, 1);
+});
+
+test("buildLayout nests all items under the root with the given revision", () => {
+  const items = buildMenuItems({ running: true, version: "0.4.2", autostart: true, hasService: true });
+  const [revision, root] = buildLayout(items, 7, 0);
+  assert.equal(revision, 7);
+  assert.equal(root[0], 0);
+  assert.equal(root[1]["children-display"].value, "submenu");
+  assert.equal(root[2].length, items.length);
+  assert.equal(root[2][0].value[0], items[0].id);
+
+  // A non-zero parent returns just that item; unknown parents return an empty node.
+  const [, node] = buildLayout(items, 8, 4);
+  assert.equal(node[0], 4);
+  const [, empty] = buildLayout(items, 9, 999);
+  assert.equal(empty[0], 999);
+  assert.equal(empty[2].length, 0);
+});
+
+test("autostart desktop file references the tray script", () => {
+  const desktop = buildAutostartDesktop("/usr/bin/node /opt/ompweb/bin/linux-tray.js --start");
+  assert.match(desktop, /^\[Desktop Entry\]/);
+  assert.match(desktop, /^Exec=\/usr\/bin\/node \/opt\/ompweb\/bin\/linux-tray\.js --start$/m);
+  assert.match(desktop, /^Terminal=false$/m);
+  assert.match(desktop, /^X-KDE-autostart-after=panel$/m);
+});
+
+test("buildAutostartExec quotes paths containing spaces", () => {
+  const exec = buildAutostartExec();
+  assert.match(exec, / --start$/);
+  const parts = exec.match(/"([^"]+)"/g);
+  if (parts) {
+    for (const part of parts) assert.ok(!part.includes(" ") || part.startsWith('"'), "spaces must be quoted");
+  }
+});
+
+test("terminal candidates honor explicit env overrides first", () => {
+  const candidates = terminalCandidates({ OMP_WEB_TERMINAL: "foot", TERMINAL: "wezterm" });
+  assert.deepEqual(candidates.slice(0, 2), ["foot", "wezterm"]);
+  assert.ok(candidates.includes("konsole"));
+});
+
+test("terminal prefix wraps gnome-terminal with -- and others with -e", () => {
+  assert.deepEqual(terminalPrefix("konsole"), ["konsole", "-e"]);
+  assert.deepEqual(terminalPrefix("gnome-terminal"), ["gnome-terminal", "--"]);
+});
+
+test("probeServer resolves true for a live listener and false for a closed port", async () => {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  assert.equal(await probeServer("127.0.0.1", port), true);
+  await new Promise((resolve) => server.close(resolve));
+  assert.equal(await probeServer("127.0.0.1", port), false);
+});
+
+test("buildTrayIconPixels renders opaque rounded square with transparent corners", () => {
+  const buffer = buildTrayIconPixels(64, true);
+  assert.equal(buffer.length, 64 * 64 * 4);
+
+  const pixel = (x, y) => {
+    const offset = (y * 64 + x) * 4;
+    return [buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]];
+  };
+  // Corners are outside the rounded box → fully transparent.
+  for (const [x, y] of [[0, 0], [63, 0], [0, 63], [63, 63]]) {
+    assert.equal(pixel(x, y)[0], 0, `corner ${x},${y} must be transparent`);
+  }
+  // Center of the box: background color #c96f4a.
+  const [a, r] = pixel(32, 8);
+  assert.equal(a, 255);
+  assert.ok(Math.abs(r - 201) <= 2, `background red must be ~201, got ${r}`);
+  // Chevron stroke passes near (30, 32) → light foreground #fff8f2.
+  const [, rFg] = pixel(30, 32);
+  assert.ok(Math.abs(rFg - 255) <= 2, `glyph red must be ~255, got ${rFg}`);
+});
+
+test("buildIconPixmap returns sized structs with matching byte counts", () => {
+  for (const size of TRAY_ICON_PIXMAP_SIZES) {
+    const pixmaps = buildIconPixmap(false);
+    const entry = pixmaps.find(([w, h]) => w === size && h === size);
+    assert.ok(entry, `missing pixmap for size ${size}`);
+    assert.equal(entry[2].length, size * size * 4);
+  }
+  // Stopped icon uses the gray background #8d8578.
+  const stopped = buildIconPixmap(false).find(([w]) => w === 64)[2];
+  assert.ok(Math.abs(stopped[(8 * 64 + 32) * 4 + 1] - 141) <= 2);
+});

--- a/bin/omp-web-options.js
+++ b/bin/omp-web-options.js
@@ -18,9 +18,9 @@ Options:
   -H, --hostname <host>    Bind hostname (default 127.0.0.1, env OMP_WEB_HOSTNAME)
       --password <pass>    Password for the web sign-in screen (env OMP_WEB_PASSWORD)
       --no-open            Do not open the browser automatically
-      --install-tray       Install Windows System Tray service & Desktop shortcuts
-      --uninstall-tray     Uninstall Windows System Tray service & shortcuts
-      --tray               Start background System Tray manager
+      --install-tray       Install system tray service & shortcuts (Windows tray / Linux SNI tray)
+      --uninstall-tray     Uninstall system tray service & shortcuts
+      --tray               Start background system tray manager
   -h, --help               Show this help
       --version            Show version
 Password:

--- a/bin/omp-web-systemd.js
+++ b/bin/omp-web-systemd.js
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+"use strict";
+
+// Install ompweb as a Linux systemd user service (starts at login, restarts on crash).
+//
+// Usage (installed as the `ompweb-systemd` bin, or run via node directly):
+//   ompweb-systemd [install|uninstall|start|stop|restart|status]
+//   npx -p @kahme247/ompweb@latest ompweb-systemd install
+//
+// The service runs the locally installed `ompweb` binary resolved at install
+// time (sibling of the running node, else on PATH; OMP_WEB_SYSTEMD_BIN override).
+//
+// Configuration (read at install time, baked into the unit):
+//   PORT                 Server port                                default 30177
+//   OMP_WEB_HOSTNAME     Server bind host                           default 127.0.0.1
+//   OMP_WEB_PASSWORD     Optional password for web login            default none (auth disabled)
+//   OMP_WEB_NO_OPEN      Set to 1 to not auto-open the browser      default 1 (no auto-open)
+//   OMP_WEB_OMP_BIN      Path to omp binary if not on PATH          default auto-detected
+//   PI_CODING_AGENT_DIR  Custom omp agent directory                 default ~/.omp/agent
+//
+// Example (loopback-only; require auth + trusted HTTPS proxy/VPN for remote access):
+//   OMP_WEB_PASSWORD=secret ompweb-systemd install
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { parseArgs } = require("util");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { spawnSync } = require("node:child_process");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require("node:fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const os = require("node:os");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("node:path");
+
+const UNIT_NAME = "ompweb";
+const UNIT = `${UNIT_NAME}.service`;
+const HOME = os.homedir();
+const UNIT_DIR = path.join(HOME, ".config", "systemd", "user");
+const UNIT_PATH = path.join(UNIT_DIR, UNIT);
+
+function printHelp() {
+  console.log(`Usage: ompweb-systemd [command] [options]
+
+Commands:
+  install      Install the ompweb user service and enable it (starts at login)
+  uninstall    Stop the service and remove the unit file
+  start        Start the service
+  stop         Stop the service
+  restart      Restart the service
+  status       Show service status (default when no command given)
+  open         Open the web service in the default browser
+  help         Show this help
+
+Options:
+  -p, --port <port>       Server port baked into the unit (default 30177, env PORT)
+  -H, --hostname <host>   Bind address baked into the unit (default 127.0.0.1, env OMP_WEB_HOSTNAME)
+      --no-autostart      Install the unit but do not enable it at login
+      --clean-config      Also delete ~/.omp/agent/web-service.json on uninstall
+      --json              Output status as JSON
+  -h, --help              Show this help
+  -v, --version           Show version
+`);
+}
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function isExecutableFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile() && fs.accessSync(candidate, fs.constants.X_OK) === undefined;
+  } catch {
+    return false;
+  }
+}
+
+function which(name) {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (dir && isExecutableFile(path.join(dir, name))) return path.join(dir, name);
+  }
+  return null;
+}
+
+function readPackageVersion() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("../package.json").version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+// Escape a value for a quoted systemd Environment="K=V" pair: backslash and
+// double quote are escaped, % is doubled (it starts specifiers like %h).
+function escapeUnitValue(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/%/g, "%%");
+}
+
+function environmentLine(entries) {
+  return entries.map(([key, value]) => `"${key}=${escapeUnitValue(value)}"`).join(" ");
+}
+
+// Resolve the ompweb binary the unit will run: explicit override wins, then
+// the sibling of the running node (npm/bun global installs), then PATH.
+// Throws when no usable binary is found; callers surface it via fail().
+function resolveOmpwebBin(env = process.env) {
+  const override = env.OMP_WEB_SYSTEMD_BIN;
+  if (override) {
+    if (!isExecutableFile(override)) throw new Error(`OMP_WEB_SYSTEMD_BIN=${override} is not executable`);
+    return override;
+  }
+  const sibling = path.join(path.dirname(process.execPath), "ompweb");
+  if (isExecutableFile(sibling)) return sibling;
+  const onPath = which("ompweb");
+  if (onPath) return onPath;
+  throw new Error("ompweb binary not found (next to node or on PATH); set OMP_WEB_SYSTEMD_BIN");
+}
+
+// Build the unit file text. Pure so tests can assert on generation.
+function buildUnit({ ompwebBin, port, hostname, env: extraEnv = {}, home = HOME }) {
+  const ompBin = extraEnv.OMP_WEB_OMP_BIN ?? null;
+  const pathDirs = [
+    ...(ompBin ? [path.dirname(ompBin)] : []),
+    path.dirname(ompwebBin),
+    path.dirname(process.execPath),
+    path.join(home, ".local", "bin"),
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+  ].filter((dir, i, all) => all.indexOf(dir) === i);
+
+  const envEntries = Object.entries({
+    PATH: pathDirs.join(path.delimiter),
+    PORT: String(port),
+    OMP_WEB_HOSTNAME: hostname,
+    OMP_WEB_NO_OPEN: "1",
+    ...extraEnv,
+  });
+
+  return `# Generated by ompweb-systemd — edits are overwritten on reinstall.
+[Unit]
+Description=ompweb web service (oh-my-pi web UI)
+Documentation=https://github.com/kahme247/ompweb#readme
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+ExecStart=${ompwebBin}
+Environment=${environmentLine(envEntries)}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+// Run systemctl --user; a missing daemon or session is a hard failure unless ignored.
+function systemctl(args, { ignoreFailure = false } = {}) {
+  const result = spawnSync("systemctl", ["--user", ...args], { encoding: "utf8" });
+  if (result.error) {
+    if (ignoreFailure) return { ok: false, stdout: "", stderr: String(result.error.message) };
+    fail(`systemctl not runnable: ${result.error.message}`);
+  }
+  const ok = result.status === 0;
+  if (!ok && !ignoreFailure) {
+    fail(`systemctl ${args.join(" ")} failed: ${(result.stderr || result.stdout || "").trim()}`);
+  }
+  return { ok, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+// systemctl --user <verb> -- <unit> exits 0/3 for active/inactive; collapse to boolean.
+function systemdQuery(args) {
+  const result = spawnSync("systemctl", ["--user", ...args], { encoding: "utf8" });
+  if (result.error) fail(`systemctl not runnable: ${result.error.message}`);
+  return { ok: result.status === 0, stdout: (result.stdout ?? "").trim() };
+}
+
+function install(options = {}) {
+  let ompwebBin;
+  try {
+    ompwebBin = resolveOmpwebBin();
+  } catch (err) {
+    fail(err.message);
+  }
+
+  const ompBin = process.env.OMP_WEB_OMP_BIN ?? which("omp");
+  if (process.env.OMP_WEB_OMP_BIN && !isExecutableFile(process.env.OMP_WEB_OMP_BIN)) {
+    fail(`OMP_WEB_OMP_BIN=${process.env.OMP_WEB_OMP_BIN} is not executable`);
+  } else if (!ompBin) {
+    console.warn("warning: omp binary not found; live-agent features will be unavailable (set OMP_WEB_OMP_BIN)");
+  }
+
+  const port = options.port ?? process.env.PORT ?? "30177";
+  const hostname = options.hostname ?? process.env.OMP_WEB_HOSTNAME ?? "127.0.0.1";
+  const password = process.env.OMP_WEB_PASSWORD;
+  const agentDir = process.env.PI_CODING_AGENT_DIR?.replace(/^~(?=\/|$)/, HOME);
+
+  const unit = buildUnit({
+    ompwebBin,
+    port,
+    hostname,
+    env: {
+      ...(password ? { OMP_WEB_PASSWORD: password } : {}),
+      ...(ompBin ? { OMP_WEB_OMP_BIN: ompBin } : {}),
+      ...(agentDir ? { PI_CODING_AGENT_DIR: agentDir } : {}),
+    },
+  });
+
+  const wasActive = systemdQuery(["is-active", "--quiet", UNIT]).ok;
+
+  fs.mkdirSync(UNIT_DIR, { recursive: true });
+  // Optional password lives in the unit as plain text; keep it user-readable only.
+  fs.writeFileSync(UNIT_PATH, unit, { mode: 0o600 });
+  fs.chmodSync(UNIT_PATH, 0o600);
+
+  systemctl(["daemon-reload"]);
+  if (options.autostart !== false) systemctl(["enable", "--now", UNIT]);
+  else systemctl(["start", UNIT], { ignoreFailure: true });
+  if (wasActive) systemctl(["restart", UNIT]);
+
+  console.log(`installed: ${UNIT_PATH}`);
+  console.log(`binary:    ${ompwebBin}`);
+  console.log(`url:       http://${hostname}:${port}`);
+  console.log(`logs:      journalctl --user -u ${UNIT_NAME} -f`);
+  if (options.autostart === false) console.log("note:      service is not enabled at login (--no-autostart)");
+  if (password) console.log("note:      password is stored in plain text in the unit (mode 600)");
+}
+
+function uninstall(options = {}) {
+  systemctl(["disable", "--now", UNIT], { ignoreFailure: true });
+  fs.rmSync(UNIT_PATH, { force: true });
+  systemctl(["daemon-reload"], { ignoreFailure: true });
+  if (options.cleanConfig) {
+    const config = path.join(HOME, ".omp", "agent", "web-service.json");
+    fs.rmSync(config, { force: true });
+    console.log(`removed:   ${config}`);
+  }
+  console.log(`uninstalled: ${UNIT_NAME}`);
+}
+
+function start() {
+  systemctl(["start", UNIT]);
+  console.log(`started: ${UNIT_NAME}`);
+}
+
+function stop() {
+  systemctl(["stop", UNIT]);
+  console.log(`stopped: ${UNIT_NAME}`);
+}
+
+function restart() {
+  systemctl(["restart", UNIT]);
+  console.log(`restarted: ${UNIT_NAME}`);
+}
+
+function readStatus() {
+  const active = systemdQuery(["is-active", UNIT]);
+  const enabled = systemdQuery(["is-enabled", UNIT]);
+  const pid = systemdQuery(["show", "--property", "MainPID", "--value", UNIT]);
+  const port = parseInt(process.env.PORT ?? "30177", 10);
+  const hostname = process.env.OMP_WEB_HOSTNAME ?? "127.0.0.1";
+  return {
+    isLinux: process.platform === "linux",
+    unit: UNIT,
+    unitPath: UNIT_PATH,
+    isInstalled: fs.existsSync(UNIT_PATH),
+    isActive: active.ok && active.stdout === "active",
+    isEnabled: enabled.ok,
+    pid: parseInt(pid.stdout, 10) || null,
+    port,
+    hostname,
+    serviceUrl: `http://${hostname}:${port}`,
+    logCommand: `journalctl --user -u ${UNIT_NAME} -f`,
+  };
+}
+
+function printStatus(asJson) {
+  const status = readStatus();
+  if (asJson) {
+    console.log(JSON.stringify(status, null, 2));
+    return status;
+  }
+  console.log(`=== omp-web systemd service status (${process.platform}) ===`);
+  console.log(`  Unit        : ${status.unit} (${status.isInstalled ? status.unitPath : "not installed"})`);
+  console.log(`  Version     : v${readPackageVersion()}`);
+  console.log(`  Active      : ${status.isActive ? `Yes (pid ${status.pid})` : "No"}`);
+  console.log(`  Start at login: ${status.isEnabled ? "Enabled" : "Disabled"}`);
+  console.log(`  Live URL    : ${status.serviceUrl}`);
+  console.log(`  Logs        : ${status.logCommand}`);
+  return status;
+}
+
+function openInBrowser() {
+  const status = readStatus();
+  const openBin = process.env.OMP_WEB_OPEN ?? which("xdg-open") ?? "xdg-open";
+  const child = spawnSync(openBin, [status.serviceUrl], { stdio: "ignore", detached: true });
+  if (child.error) console.error(`Failed to open browser: ${child.error.message}`);
+  else console.log(`Opening ${status.serviceUrl}...`);
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const { values: cliArgs, positionals } = parseArgs({
+    args: argv,
+    options: {
+      port:           { type: "string", short: "p" },
+      hostname:       { type: "string", short: "H" },
+      "no-autostart": { type: "boolean" },
+      "clean-config": { type: "boolean" },
+      json:           { type: "boolean" },
+      help:           { type: "boolean", short: "h" },
+      version:        { type: "boolean", short: "v" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  if (process.platform !== "linux") {
+    fail("systemd services are Linux-only (see ompweb-launchd for macOS, ompweb --install-tray for Windows)");
+  }
+
+  if (cliArgs.version || positionals.includes("version")) {
+    console.log(readPackageVersion());
+    return { exitCode: 0 };
+  }
+  if (cliArgs.help || positionals.includes("help")) {
+    printHelp();
+    return { exitCode: 0 };
+  }
+
+  const command = positionals[0] ?? "status";
+  const installOpts = {
+    port: cliArgs.port ? parseInt(cliArgs.port, 10) : undefined,
+    hostname: cliArgs.hostname,
+    autostart: !cliArgs["no-autostart"],
+  };
+
+  switch (command) {
+    case "install":
+      install(installOpts);
+      break;
+    case "uninstall":
+      uninstall({ cleanConfig: cliArgs["clean-config"] });
+      break;
+    case "start":
+      start();
+      break;
+    case "stop":
+      stop();
+      break;
+    case "restart":
+      restart();
+      break;
+    case "open":
+      openInBrowser();
+      break;
+    case "status": {
+      const status = printStatus(cliArgs.json);
+      return { exitCode: 0, status };
+    }
+    default:
+      console.error(`Unknown command: ${command}`);
+      printHelp();
+      return { exitCode: 2 };
+  }
+  return { exitCode: 0 };
+}
+
+if (require.main === module) {
+  runCli().then(({ exitCode }) => {
+    if (exitCode !== undefined && exitCode !== 0) process.exit(exitCode);
+  }).catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  UNIT,
+  UNIT_PATH,
+  buildUnit,
+  escapeUnitValue,
+  readStatus,
+  resolveOmpwebBin,
+  runCli,
+};

--- a/bin/omp-web-systemd.test.mjs
+++ b/bin/omp-web-systemd.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  UNIT,
+  UNIT_PATH,
+  buildUnit,
+  escapeUnitValue,
+  resolveOmpwebBin,
+  runCli,
+} = require("./omp-web-systemd.js");
+
+test("escapeUnitValue escapes backslashes, quotes, and percent specifiers", () => {
+  assert.equal(escapeUnitValue("plain"), "plain");
+  assert.equal(escapeUnitValue("back\\slash"), "back\\\\slash");
+  assert.equal(escapeUnitValue('quo"te'), "quo\\\"te");
+  assert.equal(escapeUnitValue("100%h"), "100%%h");
+});
+
+test("buildUnit renders ExecStart, environment, and install target", () => {
+  const unit = buildUnit({
+    ompwebBin: "/usr/local/bin/ompweb",
+    port: 30177,
+    hostname: "127.0.0.1",
+    env: {
+      OMP_WEB_PASSWORD: "s3cret",
+      OMP_WEB_OMP_BIN: "/home/u/.bun/bin/omp",
+    },
+    home: "/home/u",
+  });
+
+  assert.match(unit, /ExecStart=\/usr\/local\/bin\/ompweb\n/);
+  assert.match(unit, /WorkingDirectory=%h/);
+  assert.match(unit, /PORT=30177/);
+  assert.match(unit, /OMP_WEB_HOSTNAME=127\.0\.0\.1/);
+  assert.match(unit, /OMP_WEB_NO_OPEN=1/);
+  assert.match(unit, /"OMP_WEB_PASSWORD=s3cret"/);
+  assert.match(unit, /"OMP_WEB_OMP_BIN=\/home\/u\/.bun\/bin\/omp"/);
+  assert.match(unit, /Restart=on-failure/);
+  assert.match(unit, /WantedBy=default\.target/);
+  // PATH prefers the omp and ompweb directories, then node and standard bins.
+  assert.match(unit, /"PATH=\/home\/u\/.bun\/bin:\/usr\/local\/bin:.*\/usr\/bin:\/bin"/);
+  // Only one Environment line with quoted pairs.
+  const envLines = unit.split("\n").filter((line) => line.startsWith("Environment="));
+  assert.equal(envLines.length, 1);
+});
+
+test("buildUnit omits optional env entries and dedupes PATH dirs", () => {
+  const unit = buildUnit({
+    ompwebBin: "/usr/bin/ompweb",
+    port: 30177,
+    hostname: "127.0.0.1",
+    env: {},
+    home: "/home/u",
+  });
+  assert.ok(!unit.includes("OMP_WEB_PASSWORD"));
+  assert.ok(!unit.includes("OMP_WEB_OMP_BIN"));
+  assert.ok(!unit.includes("PI_CODING_AGENT_DIR"));
+});
+
+test("resolveOmpwebBin honors OMP_WEB_SYSTEMD_BIN override", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "ompweb-systemd-"));
+  try {
+    const fake = path.join(dir, "ompweb");
+    writeFileSync(fake, "#!/bin/sh\n", { mode: 0o755 });
+    assert.equal(resolveOmpwebBin({ OMP_WEB_SYSTEMD_BIN: fake }), fake);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveOmpwebBin rejects a non-executable override", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "ompweb-systemd-"));
+  try {
+    const plain = path.join(dir, "ompweb");
+    writeFileSync(plain, "not executable\n", { mode: 0o644 });
+    assert.throws(() => resolveOmpwebBin({ OMP_WEB_SYSTEMD_BIN: plain }), /not executable/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runCli with help returns exit code 0 and unit constants are stable", async () => {
+  const res = await runCli(["--help"]);
+  assert.equal(res.exitCode, 0);
+  assert.equal(UNIT, "ompweb.service");
+  assert.ok(UNIT_PATH.endsWith(path.join(".config", "systemd", "user", "ompweb.service")));
+});
+
+test("runCli rejects unknown commands with exit code 2", async () => {
+  const res = await runCli(["bogus-command"]);
+  assert.equal(res.exitCode, 2);
+});

--- a/bin/omp-web-tray.js
+++ b/bin/omp-web-tray.js
@@ -14,9 +14,14 @@ function printHelp() {
   console.log(`Usage: node bin/omp-web-tray.js [command] [options]
        ompweb-tray [command] [options]
 
+Platform notes:
+  Windows  System Tray shortcuts and background service
+  Linux    StatusNotifierItem tray (KDE Plasma and compatible) — see ompweb-systemd
+           for the systemd user service this tray manages
+
 Commands:
-  --install, install      Install Windows System Tray shortcuts and background service
-  --uninstall, uninstall  Uninstall Windows System Tray shortcuts and background service
+  --install, install      Install system tray shortcuts and background service
+  --uninstall, uninstall  Uninstall system tray shortcuts and background service
   --start, start          Start the background system tray manager
   --stop, stop            Stop running background system tray and server processes
   --restart, restart      Restart running background system tray and server
@@ -26,9 +31,9 @@ Commands:
 Options:
   -p, --port <port>       Server port for background service (default 30177)
   -H, --hostname <host>   Bind address (default 127.0.0.1)
-  -m, --mode <mode>       Execution mode: "start" or "dev" (default "start")
-      --no-autostart      Disable automatic Windows startup on logon
-      --start             Start tray manager immediately after installation
+  -m, --mode <mode>       Execution mode: "start" or "dev" (default "start", Windows only)
+      --no-autostart      Disable automatic startup on logon
+      --start             Start tray manager immediately after installation (Windows)
       --clean-config      Also delete ~/.omp/agent/web-service.json on uninstallation
       --json              Output status as JSON
   -h, --help              Show this help
@@ -37,6 +42,12 @@ Options:
 }
 
 async function runCli(argv = process.argv.slice(2)) {
+  // Linux dispatches to the StatusNotifierItem tray implementation.
+  if (process.platform === "linux") {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("./linux-tray").runCli(argv);
+  }
+
   const { values: cliArgs, positionals } = parseArgs({
     args: argv,
     options: {

--- a/bin/omp-web-tray.test.mjs
+++ b/bin/omp-web-tray.test.mjs
@@ -47,5 +47,9 @@ test("runCli with --status returns status object", async () => {
   assert.equal(res.exitCode, 0);
   assert.ok(res.status);
   assert.equal(typeof res.status.port, "number");
-  assert.equal(typeof res.status.isWindows, "boolean");
+  if (process.platform === "linux") {
+    assert.equal(res.status.isLinux, true);
+  } else {
+    assert.equal(res.status.isWindows, true);
+  }
 });

--- a/bin/omp-web.js
+++ b/bin/omp-web.js
@@ -20,6 +20,16 @@ if (process.argv[2] === "ompweb-launchd" || process.argv[2] === "launchd") {
   process.exit(status ?? 1);
 }
 
+// Forward `ompweb ompweb-systemd [args]` → bin/omp-web-systemd.js (Linux service).
+if (process.argv[2] === "ompweb-systemd" || process.argv[2] === "systemd") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { spawnSync } = require("node:child_process");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join } = require("node:path");
+  const { status } = spawnSync(process.execPath, [join(__dirname, "omp-web-systemd.js"), ...process.argv.slice(3)], { stdio: "inherit" });
+  process.exit(status ?? 1);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { spawn } = require("node:child_process");
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@base-ui/react": "^1.7.0",
         "cmdk": "^1.1.1",
+        "dbus-next": "^0.10.2",
         "katex": "^0.16.47",
         "lucide-react": "^1.39.0",
         "mammoth": "^1.12.2",
@@ -582,23 +583,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -629,13 +613,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
@@ -1618,6 +1595,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@nornagon/put": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nornagon/put/-/put-0.0.8.tgz",
+      "integrity": "sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.3.0"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -3298,6 +3284,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3320,6 +3313,33 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3334,6 +3354,25 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "node_modules/argparse": {
@@ -3525,6 +3564,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3542,6 +3601,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3557,6 +3623,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/axe-core": {
       "version": "4.11.1",
@@ -3628,6 +3711,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bluebird": {
@@ -3776,6 +3879,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3843,6 +3953,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3865,6 +3985,16 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3884,6 +4014,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3908,7 +4051,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -3916,6 +4059,13 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4475,6 +4625,19 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4534,6 +4697,24 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
       "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
+    },
+    "node_modules/dbus-next": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.10.2.tgz",
+      "integrity": "sha512-kLNQoadPstLgKKGIXKrnRsMgtAK/o+ix3ZmcfTfvBHzghiO9yHXpoKImGnB50EXwnfSFaSAullW/7UrSkAISSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nornagon/put": "0.0.8",
+        "event-stream": "3.3.4",
+        "hexy": "^0.2.10",
+        "jsbi": "^2.0.5",
+        "long": "^4.0.0",
+        "safe-buffer": "^5.1.1",
+        "xml2js": "^0.4.17"
+      },
+      "optionalDependencies": {
+        "usocket": "^0.3.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4616,6 +4797,23 @@
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -4707,6 +4905,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.408",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.408.tgz",
@@ -4745,6 +4960,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/es-abstract": {
@@ -5342,23 +5567,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5389,13 +5597,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -5497,17 +5698,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5544,7 +5770,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5598,6 +5824,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -5666,6 +5899,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -5673,6 +5931,52 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5713,6 +6017,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "node_modules/generator-function": {
@@ -5814,6 +6136,38 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5825,6 +6179,37 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -5874,7 +6259,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/hachure-fill": {
@@ -5882,6 +6267,31 @@
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5963,6 +6373,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -6245,6 +6662,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hexy": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.2.11.tgz",
+      "integrity": "sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -6278,6 +6704,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/iconv-lite": {
@@ -6333,6 +6775,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -6589,6 +7043,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -6796,6 +7263,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -6853,8 +7327,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -6914,6 +7395,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
+      "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6934,12 +7427,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "optional": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -6952,6 +7466,22 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7364,6 +7894,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -7473,6 +8009,11 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -8456,6 +8997,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -8482,6 +9046,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -8499,6 +9120,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -8613,6 +9241,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.53",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
@@ -8623,11 +9289,61 @@
         "node": ">=18"
       }
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8744,6 +9460,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/option": {
@@ -8918,6 +9644,25 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9049,14 +9794,37 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -9441,6 +10209,39 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.3.0.tgz",
@@ -9497,6 +10298,23 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/robust-predicates": {
@@ -9567,6 +10385,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9608,6 +10446,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -9623,6 +10470,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9841,6 +10695,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9860,11 +10721,49 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -9887,6 +10786,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "node_modules/strictdom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
@@ -9907,6 +10815,21 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -10035,6 +10958,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -10152,6 +11088,38 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -10222,6 +11190,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -10282,6 +11264,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10657,7 +11659,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10715,11 +11717,57 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/usocket": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/usocket/-/usocket-0.3.0.tgz",
+      "integrity": "sha512-V/H02RNiaOCJZuPoKont/y12VJaImC6C5xW7OzPFjYu9qnig0yv9hyp9E7Wqjm6d8yZuZouH3NAfDATVMgh2SQ==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.14.2",
+        "node-gyp": "^7.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -10777,7 +11825,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10878,6 +11926,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10886,6 +11944,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "bin": {
     "ompweb": "bin/omp-web.js",
     "ompweb-tray": "bin/omp-web-tray.js",
-    "ompweb-launchd": "bin/omp-web-launchd.js"
+    "ompweb-tray-linux": "bin/linux-tray.js",
+    "ompweb-launchd": "bin/omp-web-launchd.js",
+    "ompweb-systemd": "bin/omp-web-systemd.js"
   },
   "files": [
     "bin",
@@ -48,12 +50,18 @@
     "tray:uninstall": "node bin/omp-web-tray.js --uninstall",
     "tray:start": "node bin/omp-web-tray.js --start",
     "tray:status": "node bin/omp-web-tray.js --status",
+    "systemd:install": "node bin/omp-web-systemd.js install",
+    "systemd:uninstall": "node bin/omp-web-systemd.js uninstall",
+    "systemd:start": "node bin/omp-web-systemd.js start",
+    "systemd:stop": "node bin/omp-web-systemd.js stop",
+    "systemd:status": "node bin/omp-web-systemd.js status",
     "prepack": "npm run build",
     "release:check": "npm run typecheck && npm run lint && npm test && npm run build"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "cmdk": "^1.1.1",
+    "dbus-next": "^0.10.2",
     "katex": "^0.16.47",
     "lucide-react": "^1.39.0",
     "mammoth": "^1.12.2",


### PR DESCRIPTION
## What

Adds Linux platform parity for running ompweb as a background service with a system tray, alongside the existing Windows tray/service and macOS launchd agent.

### `ompweb-systemd` bin — systemd user service manager

- `install` writes `~/.config/systemd/user/ompweb.service` (mode 600 when a password is baked in), enables it at login, and starts it; `uninstall`, `start`, `stop`, `restart`, `status [--json]`, `open`
- runs the locally installed `ompweb` binary resolved at install time (sibling of node → PATH; `OMP_WEB_SYSTEMD_BIN` override), bakes `PORT`, `OMP_WEB_HOSTNAME`, `OMP_WEB_PASSWORD`, `OMP_WEB_OMP_BIN`, `PI_CODING_AGENT_DIR`, `OMP_WEB_NO_OPEN=1` into the unit, `Restart=on-failure`
- `ompweb systemd <cmd>` forwards to the bin, mirroring the existing `ompweb launchd` forwarding

### Linux system tray (`ompweb-tray` on Linux, StatusNotifierItem + DBusMenu)

- menu mirrors the Windows tray: header + live status row, Open in Browser, Copy Web URL, Start/Stop Server, Restart Server, View Logs (journalctl in the detected terminal), "Start with Plasma" checkbox (XDG autostart entry), Quit Tray
- status polling via TCP probe every 5 s; icon and menu rows flip live between running/stopped
- desktop notifications for best-effort failures (no clipboard tool, no terminal, autostart write errors)
- tray icon ships as self-contained ARGB32 `IconPixmap` (24/32/64 px) from a small pure-JS SDF rasterizer — renders deterministically even on hosts where the theme cannot resolve a freshly installed icon name (Plasma prefers a non-empty `IconName` and draws a blank otherwise)
- "Start with Plasma" toggles `~/.config/autostart/ompweb-tray.desktop`; the service itself keeps running when the tray quits, since systemd owns it

### Misc

- `npm run systemd:{install,uninstall,start,stop,status}` scripts for parity with the `tray:*` ones
- new dependency: `dbus-next` (pure JS, no native builds) — used only by the Linux tray path

## Verification

- `tsc --noEmit` and `eslint .` clean; `npm test` — 558 tests, 0 failures
- live-tested on CachyOS (Arch) + KDE Plasma 6, Wayland:
  - `ompweb-systemd install` → unit enabled, service active, serves HTTP 200; `kill -9` of the main PID recovered automatically via `Restart=on-failure`; `status`, `restart`, `stop`, `start` all verified
  - tray registers with `org.kde.StatusNotifierWatcher`; menu verified over DBus (`GetLayout`, `Event`, including the autostart toggle writing/removing the desktop entry); icon + menu state flips when the service stops and starts; tray re-registration is self-healing after a plasmashell restart

## Notes for reviewers

- `package-lock.json`: beyond dbus-next itself, npm also materialized a previously-absent optional `node-gyp → request` subtree (npm 11 reconciliation of the same lockfile). No runtime dependency changes outside dbus-next.
- KDE expects tray pixmap structs as `(iiay)` with big-endian ARGB32 pixels — matches the marshaller used by plasma-workspace's `xembed-sni-proxy`.
