### PR TITLE
fix(chat): render ANSI colors in extension widgets and statuses

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1348,7 +1348,7 @@ function ExtensionStatusBar({ statuses }: { statuses: Array<{ key: string; text:
           }}
         >
           <span style={{ color: "var(--accent)", fontFamily: "var(--font-mono)", fontSize: 11 }}>{status.key}</span>
-          <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{status.text}</span>
+          <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{renderAnsiLine(status.text, status.key)}</span>
         </div>
       ))}
     </div>
@@ -1360,23 +1360,21 @@ function ExtensionWidgets({ widgets }: { widgets: Array<{ key: string; lines: st
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 8 }}>
       {widgets.map((widget) => (
-        <div
+        <pre
           key={widget.key}
           className="ui-compact-surface"
-          style={{
-            border: "1px solid var(--border)",
-            borderRadius: "var(--radius-control)",
-            background: "var(--bg-panel)",
-            overflow: "hidden",
-          }}
+          role="group"
+          aria-label={widget.key}
+          title={widget.key}
+          style={{ margin: 0, padding: "8px 9px", fontSize: 12, lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "var(--font-mono)" }}
         >
-          <div style={{ padding: "5px 9px", borderBottom: "1px solid var(--border)", color: "var(--text-dim)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
-            {widget.key}
-          </div>
-          <pre style={{ margin: 0, padding: "8px 9px", color: "var(--text-muted)", fontSize: 12, lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "var(--font-mono)" }}>
-            {widget.lines.join("\n")}
-          </pre>
-        </div>
+          {widget.lines.map((line, index, allLines) => (
+            <Fragment key={index}>
+              {renderAnsiLine(line, `${widget.key}-${index}`)}
+              {index < allLines.length - 1 ? "\n" : null}
+            </Fragment>
+          ))}
+        </pre>
       ))}
     </div>
   );

--- a/lib/ansi.test.mjs
+++ b/lib/ansi.test.mjs
@@ -50,3 +50,12 @@ test("maps 256-color SGR codes", async () => {
     { text: "red", style: { color: "rgb(255, 0, 0)" } },
   ]);
 });
+
+test("drops non-SGR escape sequences from styled text", async () => {
+  const { parseAnsiLine } = await loadSubject();
+
+  assert.deepEqual(parseAnsiLine("\x1b[32m\x1b]8;;https://x.test\x07link\x1b]8;;\x07\x1b[39m done\x1b_pi:c\x07"), [
+    { text: "link", style: { color: "#16a34a" } },
+    { text: " done", style: {} },
+  ]);
+});

--- a/lib/ansi.ts
+++ b/lib/ansi.ts
@@ -1,7 +1,10 @@
 import type { CSSProperties } from "react";
 
-const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g;
-const ANSI_ESCAPE_AT_START_RE = /^\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/;
+// OSC must precede the single-char Fe branch, whose class `[@-Z\\-_]` also
+// matches `]`. OSC content excludes ESC so an unterminated sequence cannot
+// make every later `ESC ]` rescan to the end of the string.
+const ANSI_ESCAPE_RE = /\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g;
+const ANSI_ESCAPE_AT_START_RE = /^\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/;
 const ANSI_SGR_RE = /\x1B\[([0-9;]*)m/g;
 const TUI_CURSOR_MARKER_RE = /\x1B_pi:c\x07/g;
 
@@ -192,10 +195,13 @@ export function parseAnsiLine(line: string): AnsiSegment[] {
   let match: RegExpExecArray | null;
   ANSI_SGR_RE.lastIndex = 0;
 
+  const pushText = (raw: string) => {
+    const text = stripAnsi(raw);
+    if (text) segments.push({ text, style });
+  };
+
   while ((match = ANSI_SGR_RE.exec(line)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ text: line.slice(lastIndex, match.index), style });
-    }
+    pushText(line.slice(lastIndex, match.index));
     const codes = match[1]
       ? match[1].split(";").map((part) => Number(part || "0"))
       : [0];
@@ -203,9 +209,6 @@ export function parseAnsiLine(line: string): AnsiSegment[] {
     lastIndex = match.index + match[0].length;
   }
 
-  if (lastIndex < line.length) {
-    segments.push({ text: line.slice(lastIndex), style });
-  }
-
+  pushText(line.slice(lastIndex));
   return segments;
 }


### PR DESCRIPTION
## What

Extension widgets (`setWidget`) and statuses (`setStatus`) are written for the TUI and carry SGR escape codes. The web UI printed them verbatim, e.g. the caveman/ponytail status line:

```
[38;5;215m●[39m [38;5;114m🐴 ponytail: ⚡ FULL[39m[38;5;242m · [39m[38;5;178m🗿 caveman: ⚡ FULL[39m
```

- Render widget lines and status text through the existing `parseAnsiLine` path (already used by the extension custom panel), so SGR colors and attributes become inline styles.
- Drop the per-widget key header (`caveman`): the TUI renders widget lines only, and the key is an identifier rather than a label. It is kept as a `title` tooltip. The status chips keep their key label; they are compact and that label is part of their design.
- `parseAnsiLine` now strips non-SGR escapes (OSC hyperlinks, cursor markers) from the text it returns and skips empty segments.
- The shared escape regex matches OSC before the single-character Fe branch, whose class also matches `]` and therefore left OSC payloads (`8;;https://…`) in the visible text. OSC content excludes ESC so an unterminated sequence stays linear-time.

## Screenshots

| Light | Dark |
| --- | --- |
| ![light](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/widget-light.png) | ![dark](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/widget-dark.png) |

(Emoji render as boxes in the headless browser used for the capture; that is a font issue of the capture environment.)

## Verification

- `npx tsc --noEmit`, `npm run lint`, `node --test lib/ansi.test.mjs` (new case for OSC/APC stripping fails on `main`, passes here).
- Dev server: spawned a session with the caveman extension loaded, confirmed `/api/agent/[id]` carries the widget above, and checked the rendered `<pre>` contains colored `<span>`s and no header row.
- Adversarial input: 8 MB of unterminated `ESC ]` sequences parse in ~70 ms (was quadratic before the ESC exclusion).
