### PR TITLE
fix(shell): keep the topbar breadcrumb from overlapping the metric pills

### DIFF
--- a/components/AppShell.test.mjs
+++ b/components/AppShell.test.mjs
@@ -2,15 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 
-
-
-test("top bar renders 3-zone layout with center breadcrumb and segmented metric pills", async () => {
-  const source = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
-  assert.match(source, /className="shell-topbar-breadcrumb"/);
-  assert.match(source, /className="shell-metric-pill/);
-  assert.match(source, /position:\s*"absolute",\s*top:\s*"calc\(100% \+ 4px\)"/);
-});
-
 test("sidebar drag scales pointer deltas by the interface zoom", async () => {
   const source = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
   // clientX is viewport pixels while --sidebar-width is zoomed layout pixels;

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1637,15 +1637,11 @@ export function AppShell() {
               <div
                 className="shell-topbar-center"
                 style={{
-                  position: "absolute",
-                  left: "50%",
-                  transform: "translateX(-50%)",
+                  flex: 1,
+                  minWidth: 0,
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  maxWidth: "min(460px, calc(100% - 380px))",
-                  pointerEvents: "none",
-                  zIndex: 10,
                 }}
               >
                 <div
@@ -1664,7 +1660,6 @@ export function AppShell() {
                     whiteSpace: "nowrap",
                     minWidth: 0,
                     maxWidth: "min(400px, 30vw)",
-                    pointerEvents: "auto",
                     flexShrink: 1,
                   }}
                 >


### PR DESCRIPTION
## What

The top bar's center breadcrumb (workspace / session title) was absolutely positioned at 50% of the bar, so its width was independent of the left toolbar and the right metric pills. With a long session title and a wide right group (provider usage, context/cost, speed) the breadcrumb painted over the pills.

Lay the center zone out as a shrinking flex child between the two groups instead. It centers in the space that is actually free and the session title ellipsizes as before; the `pointer-events: auto` override on the breadcrumb is gone with the overlay it compensated for.

## Screenshots

Before (breadcrumb over the pills):

![before](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/topbar-before.png)

After:

![after](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/topbar-after.png)

## Verification

- `npx tsc --noEmit`, `npm run lint`, `node --test components/AppShell.test.mjs`.
- Dev server at 1000 px wide with a long session title and the three metric pills present: before, `breadcrumb.right = 652 > pills.left = 578`; after, `556 < 578`, and the title truncates with an ellipsis.


## Review follow-up

Removed a source-text test that passed both before and after the overlap fix; it did not measure layout behavior. The browser measurements and screenshots above are the overlap proof. The remaining sidebar test is unrelated to this fix.
