### PR TITLE
fix(composer): let Enter insert a newline on mobile

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1237,7 +1237,9 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         return;
       }
 
-      if (e.key === "Enter" && !e.shiftKey) {
+      // Soft keyboards rarely offer Shift+Enter; on the mobile breakpoint Enter
+      // inserts a newline and the Send button submits.
+      if (e.key === "Enter" && !e.shiftKey && !isMobile) {
         e.preventDefault();
         if (isStreaming && (onSteer || onFollowUp)) {
           // Submit-during-run behavior comes from Settings (Steer current run
@@ -1250,7 +1252,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         }
       }
     },
-    [isStreaming, onSteer, onFollowUp, onAbort, onMinimize, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, value, isRecording, isTranscribing, cancelDictation, stopDictation, toggleDictation]
+    [isMobile, isStreaming, onSteer, onFollowUp, onAbort, onMinimize, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, value, isRecording, isTranscribing, cancelDictation, stopDictation, toggleDictation]
   );
 
   const handleInput = useCallback(() => {


### PR DESCRIPTION
## What

On phones there is no practical Shift+Enter, so Enter on the soft keyboard sent the message and there was no way to insert a line break. On the mobile breakpoint (`useIsMobile`, ≤ 640 px) Enter now inserts a newline; the Send / Queue / Stop button in the composer footer submits. Desktop is unchanged (Enter sends, Shift+Enter inserts a newline).

The slash / `@` / history menu Enter handlers and the dictation stop shortcut run before this branch and keep working on mobile.

## Verification

- `npx tsc --noEmit`, `npm run lint`, `node --test components/ChatInput.test.mjs`.
- Dev server with a 390 px viewport: typing `line one`, Enter, `line two` leaves `line one\nline two` in the textarea and sends nothing. At 1200 px: Shift+Enter inserts a newline, Enter sends and clears the input.
