### PR TITLE
fix(mobile): resize the layout viewport for the soft keyboard

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,11 +55,16 @@ export const metadata: Metadata = {
 
 // theme-color adapts to light/dark so the browser chrome / iOS status bar
 // matches the active theme. `viewportFit: cover` lets us honor safe-area-inset
-// (used by DirectoryPicker footer) on notched devices.
+// (used by DirectoryPicker footer) on notched devices. `interactiveWidget:
+// resizes-content` makes the soft keyboard shrink the layout viewport (and
+// 100dvh) instead of only the visual one: the flex layout then keeps the
+// composer above the keyboard, rather than the browser panning the page on
+// every keystroke to reveal the caret.
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  interactiveWidget: "resizes-content",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#FAF9F6" },
     { media: "(prefers-color-scheme: dark)", color: "#1B1916" },

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1269,10 +1269,14 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
         />
       )}
 
-      {/* Full composer - always mounted; hidden when minimized to preserve ref + state */}
-      <div className="relative" style={{ flexShrink: 0, display: composerMinimized ? "none" : undefined }}>
+      {/* Full composer - always mounted; hidden when minimized to preserve ref + state.
+          A flex column that may shrink: when the panels + widgets + input are
+          taller than the viewport (soft keyboard up, Tasks expanded), the
+          panels block below scrolls and the input stays reachable instead of
+          being clipped off the bottom. */}
+      <div className="relative" style={{ display: composerMinimized ? "none" : "flex", flexDirection: "column", minHeight: 0 }}>
         {/* Minimize chevron above the composer area */}
-        <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
+        <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px`, flexShrink: 0 }}>
           <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto", display: "flex", justifyContent: "center" }}>
             <button
               type="button"
@@ -1298,6 +1302,8 @@ export function ChatWindow({ session, newSessionCwd, toolCallsDefaultCollapsed =
         <div
           style={{
             padding: `0 ${CHAT_COLUMN_PADDING}px`,
+            minHeight: 0,
+            overflowY: "auto",
           }}
         >
           <div style={{ maxWidth: CHAT_COLUMN_MAX_WIDTH, margin: "0 auto" }}>


### PR DESCRIPTION
## What

On Android Chrome, typing with the Tasks panel expanded jumped the page back to the top of the panel on every keystroke, hiding the input; collapsing the panel was the only workaround.

Chrome ≥ 108 defaults to `interactive-widget=resizes-visual`: the soft keyboard shrinks only the visual viewport, the fixed-height shell (`html, body { height: 100%; overflow: hidden }`, `100dvh` root) keeps its full size, and the browser pans the page on each keystroke to reveal the caret.

- Opt into `interactive-widget=resizes-content` via the Next `viewport` export. The keyboard now shrinks the layout viewport (and `100dvh`), the chat scroller absorbs the difference, and the composer stays above the keyboard. iOS ignores the hint, so nothing changes there.
- Make the composer a shrinkable flex column: when the panels + widgets + input are taller than the remaining space, the panels/widgets block scrolls internally instead of the input being clipped off the bottom by the shell's `overflow: hidden`. On desktop nothing moves unless the window is shorter than the composer.

## Verification

- `npx tsc --noEmit`, `npm run lint`; production build succeeds.
- Dev server, mobile emulation (390 px wide): shrinking the viewport to 300–460 px with the Tasks panel expanded keeps the textarea and Send button inside the viewport; with 600 px of extra panel content the panels block scrolls (`scrollHeight 672 > clientHeight 608`) while the input stays put.
- Not verified on a physical Android device; the keyboard behavior itself follows Chrome's documented `interactive-widget` semantics.
