### PR TITLE
fix(sidebar): align row status indicators in one column

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1581,12 +1581,8 @@ pre, code {
   from { opacity: 0; transform: translateY(-5px); }
   to { opacity: 1; transform: translateY(0); }
 }
-.sidebar-project-activity {
-  transition: transform var(--dur-fast) var(--ease-out-warm), opacity var(--dur-fast) var(--ease-out-warm);
-}
-.sidebar-project:hover .sidebar-project-activity {
-  transform: translateX(-1px);
-}
+/* The activity dot is part of the sidebar's shared right-edge status column
+   (see SessionSidebar-rows.tsx) — it must not move on hover. */
 .sidebar-project-activity[data-running="true"] .sidebar-project-activity-dot {
   position: relative;
   isolation: isolate;

--- a/components/SessionSidebar-rows.tsx
+++ b/components/SessionSidebar-rows.tsx
@@ -24,6 +24,24 @@ import {
   SidebarPortalMenu,
   UnreadSessionIndicator,
 } from "./SessionSidebar-chrome";
+
+/**
+ * Right-edge status column shared by project headers and session rows.
+ *
+ * Session rows lay out `[status slot][gap][meta]` right-aligned at
+ * `rowRight - 8`, project headers `[activity slot][gap][actions][gap][toggle]`
+ * at `rowRight - 6`. Reserving the same total width in both (`8 + 46 + 2 + 6`
+ * vs `6 + 2 + 24 + 2 + 22 + 6`) centres every indicator — running ring, unread
+ * dot, project activity dot — on `rowRight - 62`, so it never moves.
+ *
+ * The session row's indicator must live outside the meta layer: that layer
+ * fades out when the hover/focus action button takes over, and a dot rendered
+ * inside the actions layer would jump right by the width difference.
+ */
+const SIDEBAR_STATUS_SLOT = 12;
+const SIDEBAR_STATUS_GAP = 2;
+const SIDEBAR_TRAILING_META_WIDTH = 46;
+
 interface ProjectRowProps {
   project: ManagedProject;
   isActive: boolean;
@@ -299,7 +317,7 @@ function ProjectRow({
             data-running={(activity?.running ?? 0) > 0 ? "true" : "false"}
             role="status"
             aria-live="polite"
-            style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 11, height: 11, margin: "0 2px 0 0", flexShrink: 0, lineHeight: 0 }}
+            style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: SIDEBAR_STATUS_SLOT, height: SIDEBAR_STATUS_SLOT, flexShrink: 0, lineHeight: 0 }}
           >
             <span
               aria-hidden="true"
@@ -1011,15 +1029,15 @@ const SessionItem = memo(function SessionItem({
           </button>
           {session.worktreeBranch && <span title={t("sessionSidebar.worktreeTitle", { path: session.cwd })} style={{ display: "flex", alignItems: "center", gap: 3, maxWidth: 56, minWidth: 0, overflow: "hidden", color: "var(--text-dim)", fontSize: 10, flexShrink: 1 }}><GitBranch size={10} strokeWidth={2.4} aria-hidden="true" /><span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{session.worktreeBranch}</span></span>}
           {hasChildren && <button className="session-item-icon-button" onClick={(event) => { event.stopPropagation(); onToggleCollapse?.(); }} title={collapsed ? t("sessionSidebar.expandForks") : t("sessionSidebar.collapseForks")} aria-label={collapsed ? t("sessionSidebar.expandForks") : t("sessionSidebar.collapseForks")} aria-expanded={!collapsed} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 24, height: 24, padding: 0, flexShrink: 0, border: "none", background: "none", color: "var(--text-dim)", cursor: "pointer", transform: collapsed ? "rotate(-90deg)" : "none", transition: "transform var(--dur-fast) var(--ease-out-warm)" }}><ChevronDown size={12} strokeWidth={1.8} aria-hidden="true" /></button>}
-          <div style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
-            <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", width: 64, height: 24, flexShrink: 0 }}>
-              <div aria-hidden={showActions} style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 2, width: "100%", whiteSpace: "nowrap", opacity: showActions ? 0 : 1, pointerEvents: showActions ? "none" : "auto", transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>
-                {isRunning && <RunningSessionIndicator size={12} />}
-                {!isRunning && isUnread && <UnreadSessionIndicator size={11} />}
-                {relativeTime && <span title={new Date(session.modified).toLocaleString(locale)} style={{ minWidth: 42, whiteSpace: "nowrap", textAlign: "right", color: isSelected ? "var(--accent)" : "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums" }}>{relativeTime}</span>}
-              </div>
+          <div style={{ display: "flex", alignItems: "center", gap: SIDEBAR_STATUS_GAP, flexShrink: 0 }}>
+            {(isRunning || isUnread) && (
+              <span style={{ display: "flex", alignItems: "center", justifyContent: "center", width: SIDEBAR_STATUS_SLOT, height: SIDEBAR_STATUS_SLOT, flexShrink: 0 }}>
+                {isRunning ? <RunningSessionIndicator size={12} /> : <UnreadSessionIndicator size={11} />}
+              </span>
+            )}
+            <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", width: SIDEBAR_TRAILING_META_WIDTH, height: 24, flexShrink: 0 }}>
+              {relativeTime && <span aria-hidden={showActions} title={new Date(session.modified).toLocaleString(locale)} style={{ minWidth: 42, whiteSpace: "nowrap", textAlign: "right", color: isSelected ? "var(--accent)" : "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums", opacity: showActions ? 0 : 1, transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>{relativeTime}</span>}
               <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 2, opacity: showActions ? 1 : 0, pointerEvents: showActions ? "auto" : "none", transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>
-                {isRunning && <span style={{ display: "flex", alignItems: "center", marginRight: 2 }}><RunningSessionIndicator size={12} /></span>}
                 <button type="button" ref={menuButtonRef} className="session-item-icon-button" onClick={(event) => { event.stopPropagation(); setActionMenuOpen((open) => !open); }} title={t("projects.actions")} aria-label={t("projects.actions")} aria-expanded={actionMenuOpen} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 24, height: 24, padding: 0, lineHeight: 0, border: "none", borderRadius: "var(--radius-control)", background: actionMenuOpen ? "var(--bg-selected)" : "transparent", color: actionMenuOpen ? "var(--text)" : "var(--text-dim)", cursor: "pointer" }}>
                   <MoreHorizontal size={14} strokeWidth={2} aria-hidden="true" />
                 </button>


### PR DESCRIPTION
## Problem

The sidebar's right-edge status indicators (project activity dot, running ring, unread dot) each landed in a different column, and the running ring **jumped 16px right** whenever a row's hover/focus action button appeared — so a *selected* running session showed a displaced ring.

Measured on the live app (row right edge = 250px, before the fix):

| Element | x center |
|---|---|
| project activity dot | 186.5 |
| running ring, resting row | 192 |
| running ring, row with actions shown | 208 |

## Cause

- Session rows rendered the indicator **twice**: once inside the resting meta layer (`[ring][relative time 42px]`) and once inside the actions layer that fades in over it (`[ring][⋯ 24px]`). Both layers are right-aligned in the same 64px box, so swapping them moved the visible ring by the width difference (42 − 24 − 2). Introduced by "hide session meta cluster whenever row actions show".
- The project header used a third layout for the same signal: an 11px box + 2px margin before its own 24px button and 22px chevron at 6px card padding.
- A `.sidebar-project:hover .sidebar-project-activity { transform: translateX(-1px) }` nudge moved the project dot on hover.

## Fix

- The indicator now lives in one fixed 12px slot *outside* both session layers, so its x no longer depends on `showActions`; the actions overlay holds only the ⋯ button (duplicate ring removed).
- Both rows reserve the same trailing width, so every right-edge indicator centres on the same x: session `8 + 2 + 46 + 6`, project `6 + 2 + 24 + 2 + 22 + 6`.
- Removed the 1px hover nudge.

## Verification

Live DOM, after the fix: project activity dot cx **188.0**, running ring cx **188.0** — resting *and* hovered with the action button visible (`actionsOpacity: 1`). Relative-time and ⋯ button right edges unchanged (242).

`tsc --noEmit`, `eslint .`, `npm test` (629 pass, 0 fail) all clean.