### PR TITLE
fix(chat): raise the text attachment budget off the 256 KB cap

### DIFF
--- a/components/ChatInput-draft-attachments.ts
+++ b/components/ChatInput-draft-attachments.ts
@@ -1,7 +1,6 @@
 import type { ChatDraftFile, ChatDraftImage } from "@/lib/draft-store";
 import {
-  MAX_ATTACHED_TEXT_BYTES,
-  MAX_ATTACHED_TEXT_FILES,
+  selectTextAttachments,
   type AttachedTextFileData,
 } from "@/lib/chat-attachments";
 import {
@@ -40,13 +39,11 @@ export function textFileToDraftFile(file: AttachedTextFile): ChatDraftFile {
 }
 
 export function draftFilesToAttachedFiles(files: ChatDraftFile[] | undefined): AttachedTextFile[] {
-  return (files ?? [])
-    .filter((file) => typeof file.name === "string"
-      && typeof file.mimeType === "string"
-      && typeof file.content === "string"
-      && Number.isFinite(file.size)
-      && file.size <= MAX_ATTACHED_TEXT_BYTES)
-    .slice(0, MAX_ATTACHED_TEXT_FILES);
+  const shaped = (files ?? []).filter((file) => typeof file.name === "string"
+    && typeof file.mimeType === "string"
+    && typeof file.content === "string"
+    && Number.isFinite(file.size));
+  return selectTextAttachments(shaped, { usedBytes: 0, usedSlots: 0 }).accepted;
 }
 
 export function revokeImagePreview(image: AttachedImage): void {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -45,8 +45,10 @@ import { ComposerModeStatus, ModelErrorBanner, QueuedActionButton } from "./Chat
 import { CHAT_COLUMN_MAX_WIDTH } from "@/lib/chat-layout";
 import {
   composeMessageWithTextAttachments,
-  MAX_ATTACHED_TEXT_BYTES,
+  describeTextAttachmentSkip,
+  formatAttachmentBytes,
   MAX_ATTACHED_TEXT_FILES,
+  selectTextAttachments,
 } from "@/lib/chat-attachments";
 import {
   MAX_ATTACHED_IMAGE_BYTES,
@@ -328,6 +330,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
   const attachmentRevisionRef = useRef(0);
   const pendingImageCountRef = useRef(0);
   const pendingTextFileCountRef = useRef(0);
+  const pendingTextFileBytesRef = useRef(0);
   valueRef.current = value;
   attachedImagesRef.current = attachedImages;
   attachedTextFilesRef.current = attachedTextFiles;
@@ -429,7 +432,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         setAttachError(
           remaining === 0
             ? `Maximum of ${MAX_ATTACHED_IMAGES} attached images reached.`
-            : `${files.length} image(s) skipped: images up to ${Math.round(MAX_ATTACHED_IMAGE_BYTES / 1024 / 1024)} MB are supported.`,
+            : `${files.length} image(s) skipped: images up to ${formatAttachmentBytes(MAX_ATTACHED_IMAGE_BYTES)} are supported.`,
         );
       }
       return;
@@ -482,21 +485,24 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
       0,
       MAX_ATTACHED_TEXT_FILES - attachedTextFilesRef.current.length - pendingTextFileCountRef.current,
     );
-    const textFiles = files
-      .filter((file) => file.size <= MAX_ATTACHED_TEXT_BYTES)
-      .slice(0, remaining);
+    // In-flight batches reserve their bytes too, so two overlapping drops
+    // cannot each fit under the aggregate budget on their own.
+    const { accepted: textFiles, tooLarge, overBudget } = selectTextAttachments(files, {
+      usedBytes: attachedTextFilesRef.current.reduce((total, file) => total + file.size, 0) + pendingTextFileBytesRef.current,
+      usedSlots: attachedTextFilesRef.current.length + pendingTextFileCountRef.current,
+    });
+    // Report every dropped candidate, not just an entirely rejected batch: a
+    // drop of several files can lose some to the budget while accepting others.
+    const limitMessage = remaining === 0 && files.length > 0
+      ? `Maximum of ${MAX_ATTACHED_TEXT_FILES} text files reached.`
+      : describeTextAttachmentSkip({ tooLarge, overBudget });
     if (!textFiles.length) {
-      if (files.length > 0) {
-        setAttachError(
-          remaining === 0
-            ? `Maximum of ${MAX_ATTACHED_TEXT_FILES} text files reached.`
-            : `${files.length} file(s) skipped: files up to ${Math.round(MAX_ATTACHED_TEXT_BYTES / 1024)} KB are supported.`,
-        );
-      }
+      if (files.length > 0) setAttachError(limitMessage ?? `${files.length} file(s) skipped.`);
       return;
     }
     const revision = attachmentRevisionRef.current;
     pendingTextFileCountRef.current += textFiles.length;
+    pendingTextFileBytesRef.current += textFiles.reduce((total, file) => total + file.size, 0);
     try {
       const readFiles = await Promise.all(
         textFiles.map(async (file): Promise<AttachedTextFile> => ({
@@ -520,15 +526,15 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, Props>(function ChatIn
         ...prev,
         ...newFiles.slice(0, Math.max(0, MAX_ATTACHED_TEXT_FILES - prev.length)),
       ]);
-      if (skipped > 0) {
-        setAttachError(`${skipped} file(s) skipped: binary or non-text files cannot be attached.`);
-      } else {
-        setAttachError(null);
-      }
+      setAttachError(
+        limitMessage
+          ?? (skipped > 0 ? `${skipped} file(s) skipped: binary or non-text files cannot be attached.` : null),
+      );
     } catch {
       setAttachError("One or more files could not be read. Try a different file.");
     } finally {
       pendingTextFileCountRef.current -= textFiles.length;
+      pendingTextFileBytesRef.current -= textFiles.reduce((total, file) => total + file.size, 0);
     }
   }, []);
 

--- a/lib/chat-attachments.test.mjs
+++ b/lib/chat-attachments.test.mjs
@@ -57,3 +57,53 @@ test("keeps message text above attachment blocks", async () => {
   assert.ok(result.includes("Attached file: b.md") === false);
   assert.ok(result.includes("Attached file: b.txt"));
 });
+
+test("selects attachments under the per-file and aggregate budgets", async () => {
+  const { selectTextAttachments, MAX_ATTACHED_TEXT_BYTES, MAX_TOTAL_ATTACHED_TEXT_BYTES } = await loadSubject();
+  const file = (name, size) => ({ name, size });
+
+  // A lone file may fill the whole budget, and 8x the old 256 KB cap fits.
+  const large = selectTextAttachments([file("big.log", 2 * 1024 * 1024)], { usedBytes: 0, usedSlots: 0 });
+  assert.deepEqual(large.accepted.map((f) => f.name), ["big.log"]);
+  assert.equal(large.tooLarge, 0);
+  assert.equal(large.overBudget, 0);
+  assert.equal(MAX_ATTACHED_TEXT_BYTES, MAX_TOTAL_ATTACHED_TEXT_BYTES);
+
+  // Past the per-file cap the file is refused for its own size, not the budget.
+  const oversized = selectTextAttachments([file("huge.log", MAX_ATTACHED_TEXT_BYTES + 1)], { usedBytes: 0, usedSlots: 0 });
+  assert.deepEqual(oversized.accepted, []);
+  assert.equal(oversized.tooLarge, 1);
+  assert.equal(oversized.overBudget, 0);
+
+  // The aggregate budget counts what the composer already holds, and files
+  // that no longer fit are reported separately from oversized ones.
+  const partial = selectTextAttachments(
+    [file("fits.txt", 1024 * 1024), file("over.txt", 2 * 1024 * 1024), file("huge.log", MAX_ATTACHED_TEXT_BYTES + 1)],
+    { usedBytes: 3 * 1024 * 1024, usedSlots: 1 },
+  );
+  assert.deepEqual(partial.accepted.map((f) => f.name), ["fits.txt"]);
+  assert.equal(partial.tooLarge, 1);
+  assert.equal(partial.overBudget, 1);
+
+  // Remaining file slots cap the batch even when every file fits.
+  const slots = selectTextAttachments([file("a.txt", 1), file("b.txt", 1)], { usedBytes: 0, usedSlots: 9 });
+  assert.deepEqual(slots.accepted.map((f) => f.name), ["a.txt"]);
+  assert.equal(slots.tooLarge, 0);
+  assert.equal(slots.overBudget, 0);
+});
+
+test("skip banners name the limit the batch actually hit", async () => {
+  const { describeTextAttachmentSkip, formatAttachmentBytes } = await loadSubject();
+
+  assert.equal(formatAttachmentBytes(512 * 1024), "512 KB");
+  assert.equal(formatAttachmentBytes(4 * 1024 * 1024), "4 MB");
+  assert.equal(describeTextAttachmentSkip({ tooLarge: 0, overBudget: 0 }), null);
+  assert.equal(
+    describeTextAttachmentSkip({ tooLarge: 2, overBudget: 1 }),
+    "2 file(s) skipped: files up to 4 MB are supported.",
+  );
+  assert.equal(
+    describeTextAttachmentSkip({ tooLarge: 0, overBudget: 3 }),
+    "3 file(s) skipped: attachments are limited to 4 MB per message.",
+  );
+});

--- a/lib/chat-attachments.ts
+++ b/lib/chat-attachments.ts
@@ -1,4 +1,17 @@
-export const MAX_ATTACHED_TEXT_BYTES = 256 * 1024;
+/**
+ * Text-attachment budget.
+ *
+ * Nothing on the OMP side limits these: attached file contents are inlined
+ * into the prompt as text, and OMP's RPC transport advertises (in its `ready`
+ * frame) `maxFrameBytes` 1 MiB with chunked v2 frames reassembling up to
+ * 64 MiB — omp/18.1.17 accepts a 3 MB logical command frame. The binding
+ * ceilings are omp-web's own 8 MiB JSON request body
+ * (`MAX_AGENT_COMMAND_REQUEST_BYTES`) and the model's context window, so the
+ * budget is enforced on the aggregate rather than per file.
+ */
+export const MAX_TOTAL_ATTACHED_TEXT_BYTES = 4 * 1024 * 1024;
+/** A lone file may fill the whole text budget. */
+export const MAX_ATTACHED_TEXT_BYTES = MAX_TOTAL_ATTACHED_TEXT_BYTES;
 export const MAX_ATTACHED_TEXT_FILES = 10;
 
 const TEXT_FILE_EXTENSIONS: Record<string, true> = {
@@ -18,6 +31,72 @@ export interface AttachedTextFileData {
 
 function getFileExtension(name: string): string {
   return name.toLowerCase().replace(/\\/g, "/").split("/").pop()?.split(".").pop() ?? "";
+}
+
+/** Human-readable limit for the composer banners ("512 KB" / "4 MB"). */
+export function formatAttachmentBytes(bytes: number): string {
+  return bytes >= 1024 * 1024
+    ? `${Math.round(bytes / (1024 * 1024))} MB`
+    : `${Math.round(bytes / 1024)} KB`;
+}
+
+/** What the composer already holds (or has in flight) when a new batch lands. */
+export interface TextAttachmentBudget {
+  usedBytes: number;
+  usedSlots: number;
+}
+
+export interface TextAttachmentSelection<T> {
+  accepted: T[];
+  /** Candidates dropped for exceeding the per-file cap. */
+  tooLarge: number;
+  /** Candidates dropped because the message's aggregate text budget was spent. */
+  overBudget: number;
+}
+
+/**
+ * Per-file, aggregate, and slot rules for text attachments — the single place
+ * the composer and draft restore both enforce them. Candidates past the
+ * remaining slots are dropped silently, matching the count cap handled by the
+ * caller; a candidate too large on its own is reported before a budget miss so
+ * the banner names the limit the user actually hit.
+ */
+export function selectTextAttachments<T extends { size: number }>(
+  candidates: readonly T[],
+  budget: TextAttachmentBudget,
+): TextAttachmentSelection<T> {
+  const accepted: T[] = [];
+  const remainingSlots = Math.max(0, MAX_ATTACHED_TEXT_FILES - budget.usedSlots);
+  let totalBytes = budget.usedBytes;
+  let tooLarge = 0;
+  let overBudget = 0;
+  for (const candidate of candidates) {
+    if (accepted.length >= remainingSlots) break;
+    if (!Number.isFinite(candidate.size) || candidate.size > MAX_ATTACHED_TEXT_BYTES) {
+      tooLarge++;
+      continue;
+    }
+    if (totalBytes + candidate.size > MAX_TOTAL_ATTACHED_TEXT_BYTES) {
+      overBudget++;
+      continue;
+    }
+    totalBytes += candidate.size;
+    accepted.push(candidate);
+  }
+  return { accepted, tooLarge, overBudget };
+}
+
+/** Banner text for a batch that produced no usable attachments. */
+export function describeTextAttachmentSkip(
+  selection: Pick<TextAttachmentSelection<unknown>, "tooLarge" | "overBudget">,
+): string | null {
+  if (selection.tooLarge > 0) {
+    return `${selection.tooLarge} file(s) skipped: files up to ${formatAttachmentBytes(MAX_ATTACHED_TEXT_BYTES)} are supported.`;
+  }
+  if (selection.overBudget > 0) {
+    return `${selection.overBudget} file(s) skipped: attachments are limited to ${formatAttachmentBytes(MAX_TOTAL_ATTACHED_TEXT_BYTES)} per message.`;
+  }
+  return null;
 }
 
 export function isTextAttachmentFile(file: Pick<File, "name" | "type">): boolean {


### PR DESCRIPTION
## Problem

Dropping a text/markdown file larger than 256 KB into the composer is refused:

> 1 file(s) skipped: files up to 256 KB are supported.

## Is 256 KB an OMP limit? No

`MAX_ATTACHED_TEXT_BYTES` is omp-web's own number (`lib/chat-attachments.ts`, introduced with the feature in 5ac80a07); it is not derived from any OMP or transport constraint. Attached text is inlined into the prompt by `composeMessageWithTextAttachments`, and OMP's transport accepts far more than that — probed against the installed binary (`omp --mode rpc-ui`, throwaway agent dir):

```json
{"type":"ready","protocolVersion":1,"supportedProtocolVersions":[1,2],"maxFrameBytes":1048576,"maxReassembledFrameBytes":67108864}
```

A 3,145,775-byte logical command frame (chunked v2) round-trips as `success=true`, and the session file writing 3 MB names is only blocked in the *response* direction. The binding ceilings are instead:

- omp-web's own request cap, `MAX_AGENT_COMMAND_REQUEST_BYTES` = 8 MiB (Next 16.3 buffers the body in `proxy.ts` with a 10 MB default), and
- the model's context window, since the text lands in the prompt.

So the 256 KB per-file cap was 32× below the transport budget it was protecting.

## Fix

- Budget the **aggregate** instead of one file: `MAX_TOTAL_ATTACHED_TEXT_BYTES = 4 MiB` (half the request cap, leaving headroom for JSON escaping), with a lone file allowed to fill it — mirroring how the image constants are shaped.
- One `selectTextAttachments()` helper enforces per-file, aggregate, and slot rules for both the composer and draft restore.
- A partially rejected drop now reports the files it dropped; previously a batch that lost some files kept silent.

## Verification

Live composer on an isolated build (worktree of this branch, dev server on :30179):

| Drop | Result |
|---|---|
| 1.5 MB file | attached, no banner |
| 4.5 MB file | `1 file(s) skipped: files up to 4 MB are supported.` |
| two 3 MB files | first attached + `1 file(s) skipped: attachments are limited to 4 MB per message.` |

Request-budget math for a full 4 MiB text message: JSON body 4,194,655 bytes vs the 8,388,608 cap, `validateOutgoingPrompt` returns `null`. Pathological escaping (every byte a control character) would reach 25 MB and is refused at send by the existing preflight.

`tsc --noEmit`, `eslint .`, `npm test` (631 pass, 0 fail; the new budget/banner cases are in `lib/chat-attachments.test.mjs`).