### PR TITLE
fix(shell): keep a dismissed update toast dismissed

### DIFF
--- a/components/AppShell-app-update.ts
+++ b/components/AppShell-app-update.ts
@@ -1,6 +1,7 @@
 import type { AppUpdateInfo } from "./AppUpdateDialog";
 
 export const DISMISSED_APP_UPDATE_KEY = "omp-web:dismissed-app-update";
+export const DISMISSED_OMP_UPDATE_KEY = "omp-web:dismissed-omp-update";
 export const COMPLETED_APP_UPDATE_KEY = "omp-web:completed-app-update";
 export const APP_UPDATE_POLL_MS = 500;
 export const APP_UPDATE_STOPPING_POLL_MS = 200;
@@ -9,6 +10,27 @@ export const APP_UPDATE_PREPARING_MIN_MS = 1_000;
 export const APP_UPDATE_VISIBLE_STAGE_MIN_MS = 1_000;
 export const APP_UPDATE_COMPLETED_RELOAD_MS = 3_000;
 export const APP_UPDATE_ERROR_MAX_LENGTH = 240;
+
+/**
+ * Dismissed-update versions, remembered per notification. Closing an update
+ * toast must survive the visibilitycheck that re-runs the update checks, and
+ * localStorage throws in private mode / at quota.
+ */
+export function readDismissedVersion(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function rememberDismissedVersion(key: string, version: string): void {
+  try {
+    window.localStorage.setItem(key, version);
+  } catch {
+    // Dismissal is best-effort: the toast stays closed for this page anyway.
+  }
+}
 
 export async function waitForAppUpdateDwell(startedAt: number | null, minimumMs: number): Promise<void> {
   if (startedAt == null) return;

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -34,8 +34,11 @@ import {
   AppUpdateTransportError,
   COMPLETED_APP_UPDATE_KEY,
   DISMISSED_APP_UPDATE_KEY,
+  DISMISSED_OMP_UPDATE_KEY,
   fetchAppUpdateJson,
   isExactLegacyTargetCompletion,
+  readDismissedVersion,
+  rememberDismissedVersion,
   sanitizeAppUpdateError,
   waitForAppUpdateDwell,
 } from "./AppShell-app-update";
@@ -249,6 +252,10 @@ export function AppShell() {
       .then((data: { currentVersion?: string | null; availableVersion?: string | null; updateAvailable?: boolean; updateCommand?: string } | null) => {
         setOmpUpdateAvailable(Boolean(data?.updateAvailable));
         if (!data?.updateAvailable || !data.availableVersion) return;
+        // This check re-runs on every visibilitychange back to the tab, so a
+        // version the user already dismissed must not be re-announced.
+        if (readDismissedVersion(DISMISSED_OMP_UPDATE_KEY) === data.availableVersion) return;
+        const version = data.availableVersion;
         const cmd = data.updateCommand || "omp update";
         toast.info(
           translate("appShell.ompUpdateAvailable"),
@@ -281,7 +288,7 @@ export function AppShell() {
               </button>
             </div>
           </div>,
-          { id: "omp-update-available", timeout: 0 }
+          { id: "omp-update-available", timeout: 0, onClose: () => rememberDismissedVersion(DISMISSED_OMP_UPDATE_KEY, version) }
         );
       })
       .catch(() => {});
@@ -311,15 +318,15 @@ export function AppShell() {
 
     if (autoOpen && !data.selfUpdateStatus && data.updateAvailable && data.availableVersion) {
       if (data.selfUpdateSupported === true) {
-        let dismissed: string | null = null;
-        try { dismissed = window.localStorage.getItem(DISMISSED_APP_UPDATE_KEY); } catch {}
-        if (dismissed !== data.availableVersion) {
+        if (readDismissedVersion(DISMISSED_APP_UPDATE_KEY) !== data.availableVersion) {
           setAppUpdatePhase("idle");
           setAppUpdateError(null);
           setAppUpdateDialogOpen(true);
         }
       } else {
         const cmd = data.updateCommand || "npm install -g @kahme247/ompweb";
+        const version = data.availableVersion;
+        if (readDismissedVersion(DISMISSED_APP_UPDATE_KEY) === version) return data;
         toast.info(
           translate("appShell.appUpdateAvailable"),
           <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 4 }}>
@@ -351,7 +358,7 @@ export function AppShell() {
               </button>
             </div>
           </div>,
-          { id: "app-update-available", timeout: 0 }
+          { id: "app-update-available", timeout: 0, onClose: () => rememberDismissedVersion(DISMISSED_APP_UPDATE_KEY, version) }
         );
       }
     }
@@ -566,7 +573,7 @@ export function AppShell() {
 
   const dismissAppUpdate = useCallback(() => {
     if (appUpdatePhase === "idle" && appUpdate?.availableVersion) {
-      try { window.localStorage.setItem(DISMISSED_APP_UPDATE_KEY, appUpdate.availableVersion); } catch {}
+      rememberDismissedVersion(DISMISSED_APP_UPDATE_KEY, appUpdate.availableVersion);
       toast.info(t("appUpdateDialog.settingsLater"));
     }
     setAppUpdateDialogOpen(false);

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -33,6 +33,8 @@ interface ToastOptions {
   duration?: number;
   /** Stable id for deduplication — same id will replace existing toast instead of stacking. */
   id?: string;
+  /** Fired when the toast closes (dismissed by the user, `toast.close`, or timeout). */
+  onClose?: () => void;
 }
 
 const manager = Toast.createToastManager<ToastData>();
@@ -48,6 +50,7 @@ function add(kind: ToastKind, title: React.ReactNode, description?: React.ReactN
     type: kind,
     data: { kind, clamp: options?.clamp },
     ...(timeout !== undefined ? { timeout } : {}),
+    ...(options?.onClose ? { onClose: options.onClose } : {}),
   });
 }
 export const toast = {


### PR DESCRIPTION
## Report

> When there is an update popup and I close it, go out of the tab and return to the tab, it reappears again.

## Cause

The OMP update check re-runs on **every return to the tab**: `AppShell` listens for `visibilitychange` and bumps `updateCheckKey`, which re-runs the `/api/omp-update` effect — and every successful check re-raised the toast. Nothing recorded a dismissal, unlike the app-update *dialog*, which already persists one via `DISMISSED_APP_UPDATE_KEY`.

```ts
setUpdateCheckKey((key) => key + 1);   // visibilitychange
...
toast.info(..., { id: "omp-update-available", timeout: 0 });  // ran again, always
```

`toast.close(...)` only removed the toast from the manager; the next check built it again. The non-self-updating app-update toast (`app-update-available`, shown when the install isn't managed) had the same defect.

## Fix

- `rememberDismissedVersion`/`readDismissedVersion` in `AppShell-app-update.ts` (one place that tolerates localStorage throwing in private mode), with a new `DISMISSED_OMP_UPDATE_KEY` next to the app-update key.
- The update checks skip announcing a version the user already dismissed.
- `ToastOptions` gains `onClose`, forwarded to the base-ui manager, so the update toasts record their dismissal when the user closes them (the "Update now" button closes the toast too — that counts as acknowledged).
- The existing inline `localStorage` reads/writes in `AppShell` now use the shared helpers.

## Verification

Browser, against a simulated update payload (`/api/omp-update` intercepted to report `18.1.16 → 18.1.17`), counting toasts that are not in base-ui's `data-ending-style` state and forcing a frame after each step:

| Step | live update toasts | stored dismissal |
|---|---|---|
| check runs | 1 | — |
| user closes the toast | 0 | `18.1.17` |
| leave the tab and come back | **0** | `18.1.17` |
| control: forget the dismissal, come back | 1 | — |

The last row is the pre-fix behavior, so the gate is demonstrably what stops the reappearance.

`tsc --noEmit`, `eslint` on the changed files, `npm test` (641 tests, 0 fail) clean.