### PR TITLE
fix(mobile): keep theme picker inside viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 ### Fixes & Improvements
 
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
+- Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.
 
 ---
 

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -181,8 +181,7 @@ export function ThemeSwitcher() {
           style={{
             position: "absolute",
             top: "calc(100% + 4px)",
-            left: isMobile ? undefined : 0,
-            right: isMobile ? 0 : undefined,
+            left: 0,
             zIndex: 50,
             minWidth: isMobile ? 220 : 350,
             maxWidth: "92vw",


### PR DESCRIPTION
## Summary
Fix the theme picker opening off the left edge of mobile screens. Its trigger is near the toolbar's left edge, but the mobile menu used `right: 0`, placing most of the 220px menu outside the viewport.

Use `left: 0` on mobile as well as desktop. Menu sizing, scrolling, keyboard handling, and desktop alignment remain unchanged. Includes a changelog entry.

## Verification
- Browser verification on the actual application: menu bounds x=48..268 at widths 320, 375, and 390px; x=36..386 at widths 768, 1024, and 1440px.
- Keyboard opening, theme selection, dismissal, and focus return exercised.
- Deployed to a protected preview; the reporter confirmed the fix works on their device.
- Fresh checks against current upstream main: typecheck and lint passed; tests: 630 passed, 1 skipped, 0 failed.
- Earlier fork validation: Linux and Windows CI passed; condensed adversarial review, Copilot, and CodeRabbit found no issues: https://github.com/andrebrait/ompweb/pull/10.

This branch contains only the picker fix and changelog entry, without fork-specific CI changes.