### PR TITLE
fix(sidebar): keep mobile menus beside timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 
 ### Fixes & Improvements
 
+- Keep session action menus visible on touch devices beside fixed-width, right-aligned timestamps, with larger tap targets and titles using the remaining row width.
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
 - Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 ### Fixes & Improvements
 
 - Keep session action menus visible on touch devices beside fixed-width, right-aligned timestamps, with larger tap targets and titles using the remaining row width.
+- Keep workspace header action menus visible on touch devices without first selecting or expanding the workspace.
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
 - Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1517,6 +1517,68 @@ pre, code {
   border-radius: 4px;
 }
 
+.session-item-trailing {
+  height: 24px;
+}
+.session-item-metadata {
+  width: 100%;
+}
+.session-item-time {
+  width: 42px;
+}
+.session-item-actions {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.session-item-menu-button {
+  width: 24px;
+  height: 24px;
+}
+[data-actions-visible="true"] .session-item-metadata {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+[data-actions-visible="true"] .session-item-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Touch rows keep the compact timestamp immediately beside a full-size menu target. */
+@media (hover: none), (pointer: coarse) {
+  .session-item-row {
+    min-height: 44px;
+  }
+  .session-item-trailing {
+    --session-trailing-width: auto;
+    height: 44px;
+    gap: 2px;
+  }
+  .session-item-row .session-item-metadata {
+    width: auto;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+  .session-item-time {
+    width: 32px;
+  }
+  .session-item-row .session-item-actions {
+    position: static;
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .session-item-menu-button {
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+  }
+  .session-item-row .session-item-button {
+    align-self: stretch;
+  }
+}
+
 .sidebar-project-header > button:focus-visible,
 .sidebar-project-identity:focus-visible,
 .sidebar-project-action:focus-visible,

--- a/app/globals.css
+++ b/app/globals.css
@@ -1545,8 +1545,18 @@ pre, code {
   pointer-events: auto;
 }
 
+.sidebar-project-actions {
+  visibility: hidden;
+}
+.sidebar-project-actions[data-actions-visible="true"] {
+  visibility: visible;
+}
+
 /* Touch rows keep the compact timestamp immediately beside a full-size menu target. */
 @media (hover: none), (pointer: coarse) {
+  .sidebar-project-actions {
+    visibility: visible;
+  }
   .session-item-row {
     min-height: 44px;
   }

--- a/components/SessionSidebar-rows.tsx
+++ b/components/SessionSidebar-rows.tsx
@@ -28,7 +28,7 @@ import {
 /**
  * Right-edge status column shared by project headers and session rows.
  *
- * Session rows lay out `[status slot][gap][meta]` right-aligned at
+ * Desktop session rows lay out `[status slot][gap][meta]` right-aligned at
  * `rowRight - 8`, project headers `[activity slot][gap][actions][gap][toggle]`
  * at `rowRight - 6`. Reserving the same total width in both (`8 + 46 + 2 + 6`
  * vs `6 + 2 + 24 + 2 + 22 + 6`) centres every indicator — running ring, unread
@@ -959,6 +959,8 @@ const SessionItem = memo(function SessionItem({
 
   return (
     <div
+      className="session-item-row"
+      data-actions-visible={showActions}
  onClick={confirmArchive || confirmDelete || renaming ? undefined : onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -1035,10 +1037,12 @@ const SessionItem = memo(function SessionItem({
                 {isRunning ? <RunningSessionIndicator size={12} /> : <UnreadSessionIndicator size={11} />}
               </span>
             )}
-            <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", width: SIDEBAR_TRAILING_META_WIDTH, height: 24, flexShrink: 0 }}>
-              {relativeTime && <span aria-hidden={showActions} title={new Date(session.modified).toLocaleString(locale)} style={{ minWidth: 42, whiteSpace: "nowrap", textAlign: "right", color: isSelected ? "var(--accent)" : "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums", opacity: showActions ? 0 : 1, transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>{relativeTime}</span>}
-              <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 2, opacity: showActions ? 1 : 0, pointerEvents: showActions ? "auto" : "none", transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>
-                <button type="button" ref={menuButtonRef} className="session-item-icon-button" onClick={(event) => { event.stopPropagation(); setActionMenuOpen((open) => !open); }} title={t("projects.actions")} aria-label={t("projects.actions")} aria-expanded={actionMenuOpen} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 24, height: 24, padding: 0, lineHeight: 0, border: "none", borderRadius: "var(--radius-control)", background: actionMenuOpen ? "var(--bg-selected)" : "transparent", color: actionMenuOpen ? "var(--text)" : "var(--text-dim)", cursor: "pointer" }}>
+            <div className="session-item-trailing" style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", width: `var(--session-trailing-width, ${SIDEBAR_TRAILING_META_WIDTH}px)`, flexShrink: 0 }}>
+              <div className="session-item-metadata" style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>
+                {relativeTime && <span className="session-item-time" title={new Date(session.modified).toLocaleString(locale)} style={{ flexShrink: 0, whiteSpace: "nowrap", textAlign: "right", color: isSelected ? "var(--accent)" : "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums" }}>{relativeTime}</span>}
+              </div>
+              <div className="session-item-actions" style={{ inset: 0, display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 2, transition: "opacity var(--dur-fast) var(--ease-out-warm)" }}>
+                <button type="button" ref={menuButtonRef} className="session-item-icon-button session-item-menu-button" onClick={(event) => { event.stopPropagation(); setActionMenuOpen((open) => !open); }} title={t("projects.actions")} aria-label={t("projects.actions")} aria-expanded={actionMenuOpen} style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: 0, lineHeight: 0, border: "none", borderRadius: "var(--radius-control)", background: actionMenuOpen ? "var(--bg-selected)" : "transparent", color: actionMenuOpen ? "var(--text)" : "var(--text-dim)", cursor: "pointer" }}>
                   <MoreHorizontal size={14} strokeWidth={2} aria-hidden="true" />
                 </button>
                 <SidebarPortalMenu anchor={menuButtonRef} open={actionMenuOpen} onClose={() => setActionMenuOpen(false)} placement="below" minWidth={128}>

--- a/components/SessionSidebar-rows.tsx
+++ b/components/SessionSidebar-rows.tsx
@@ -332,9 +332,10 @@ function ProjectRow({
           </span>
         )}
         <div
+          className="sidebar-project-actions"
+          data-actions-visible={showActions ? "true" : "false"}
           style={{
             flexShrink: 0,
-            visibility: showActions ? "visible" : "hidden",
           }}
         >
           <button


### PR DESCRIPTION
## Problem
Session action menus depended on hover/focus, making Archive and Delete hard to reach on touch devices. Keeping the existing overlay visible would cover the relative timestamp.

## Changes
- Always show session menus on non-hover/coarse-pointer devices.
- Right-align each timestamp in a fixed 32px column immediately before the 44px menu target, with a 2px gap. Session titles use the remaining width.
- Increase touch rows to 44px without changing desktop row or menu sizes.
- Preserve the existing status-indicator alignment patch: indicators remain outside the fading metadata layer, and the desktop trailing slot stays 46px.
- Keep timestamps accessible after a touch menu opens while preserving desktop overlay accessibility behavior.
- Reuse existing handlers and archive restrictions; no gesture library, new dependency, or unrelated navigation change.

## Verification
- The user tested these exact sidebar component and stylesheet files in the patched live installation and confirmed the behavior works as intended.
- Real Chromium checks covered fixed geometry, visible timestamps, menu access without selecting a session, desktop keyboard/hover behavior, and accessibility-tree visibility. Archive/delete handler targeting was exercised only on isolated fixtures, not real user sessions.
- Current upstream branch: typecheck and ESLint passed; 630 tests passed, 1 existing Windows-only skip, 0 failures.
- The integrated installed release also passed its production build and 653 tests, with 1 existing skip.

Only the sidebar component, stylesheet, and changelog are changed. The user's other installed patches remain separate and are not included in this PR.