### PR TITLE
fix: center header and keep file-panel controls visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 
 ### Fixes & Improvements
 
+- Center the workspace/session breadcrumb over the conversation column, and keep mobile generation speed and file-panel controls clear of the panel toggle. Explorer actions now have a separate touch-sized toolbar on mobile.
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
 - Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 ### Fixes & Improvements
 
 - Center the workspace/session breadcrumb over the conversation column, and keep mobile generation speed and file-panel controls clear of the panel toggle. Explorer actions now have a separate touch-sized toolbar on mobile.
+- Keep resized file panels and their contents inside the window at intermediate widths and non-default interface scales, wrapping file and Explorer actions when space is tight.
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
 - Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 ### Fixes & Improvements
 
 - Center the workspace/session breadcrumb over the conversation column, and keep mobile generation speed and file-panel controls clear of the panel toggle. Explorer actions now have a separate touch-sized toolbar on mobile.
+- Keep the top bar on one row at high generation speeds. Average speed shows AVG instead of the lightning icon. Long rates truncate with the full value in the tooltip; the speed pill is hidden when too little space remains to read it.
 - Keep resized file panels and their contents inside the window at intermediate widths and non-default interface scales, wrapping file and Explorer actions when space is tight.
 - Hide the Steer action when the only queued message is already a steer, matching the expanded queue while keeping Edit and Delete available.
 - Keep the theme picker inside the mobile viewport by opening it to the right of its toolbar anchor.

--- a/app/globals.css
+++ b/app/globals.css
@@ -2671,6 +2671,10 @@ html.dark .dropdown-surface :is(select, option) {
   background: var(--border);
   flex-shrink: 0;
 }
+  .right-panel-toolbar > [role="toolbar"] {
+    flex-wrap: wrap;
+    max-width: 100%;
+  }
 @media (max-width: 640px) {
   .shell-toolbar-btn {
     width: 40px;
@@ -2683,10 +2687,6 @@ html.dark .dropdown-surface :is(select, option) {
     display: flex;
     align-items: center;
     min-height: 44px;
-  }
-  .right-panel-toolbar > [role="toolbar"] {
-    flex-wrap: wrap;
-    max-width: 100%;
   }
   .right-panel-toolbar > [role="toolbar"] > button {
     min-width: 40px;
@@ -3256,24 +3256,19 @@ html.dark .dropdown-surface :is(select, option) {
   .right-panel-container {
     overflow: hidden;
     transition: width var(--dur-med) var(--ease-out-warm), min-width var(--dur-med) var(--ease-out-warm);
-    flex-shrink: 0;
+    flex-shrink: 1;
   }
   .right-panel-container.right-panel-open {
     width: var(--right-panel-width, 42%);
-    min-width: 300px;
+    min-width: 0;
   }
   .right-panel-container.right-panel-closed {
     width: 0;
     min-width: 0;
     border-left: none !important;
   }
-  /* keep inner content at fixed width so it doesn't reflow during animation */
+  /* Follow the panel's available width, including interface scaling and borders. */
   .right-panel-container > * {
-    width: 42vw;
-    min-width: 300px;
-  }
-  /* user-chosen pixel width: content follows the container instead */
-  .right-panel-container.right-panel-custom-width > * {
     width: 100%;
     min-width: 0;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2679,6 +2679,72 @@ html.dark .dropdown-surface :is(select, option) {
   .shell-toolbar-divider {
     margin: 0 4px;
   }
+  .right-panel-toolbar > div:first-child {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+  }
+  .right-panel-toolbar > [role="toolbar"] {
+    flex-wrap: wrap;
+    max-width: 100%;
+  }
+  .right-panel-toolbar > [role="toolbar"] > button {
+    min-width: 40px;
+    min-height: 40px;
+  }
+  .right-panel-toolbar .tabbar-scroll {
+    width: 100%;
+  }
+  .right-panel-toolbar .tabbar-scroll,
+  .right-panel-toolbar .tabbar-tab {
+    height: 44px !important;
+  }
+}
+
+.shell-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+.shell-topbar-center {
+  position: absolute;
+  top: 4.5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: clamp(0px, calc(100% - 480px), 400px);
+  pointer-events: none;
+}
+.shell-topbar-center > .shell-topbar-breadcrumb {
+  pointer-events: auto;
+}
+
+/* Hide only the breadcrumb when the sidebars leave too little title space. */
+@container breadcrumb (max-width: 180px) {
+  .shell-topbar-breadcrumb {
+    visibility: hidden;
+  }
+}
+
+@media (max-width: 960px) {
+  .shell-topbar-center {
+    display: none !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .shell-topbar {
+    gap: 0 4px !important;
+    padding-right: 48px !important;
+  }
+  .shell-topbar-tools {
+    gap: 2px !important;
+  }
+  .shell-topbar .shell-toolbar-divider {
+    margin: 0;
+  }
+  .shell-topbar [data-topbar-right-group] {
+    padding: 0 0 4px !important;
+  }
 }
 
 /* Top bar center breadcrumb */
@@ -2731,11 +2797,6 @@ html.dark .dropdown-surface :is(select, option) {
   border-color: var(--accent);
 }
 
-@media (max-width: 960px) {
-  .shell-topbar-center {
-    display: none !important;
-  }
-}
 
 @media (max-width: 640px) {
   .shell-metric-pill {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2703,7 +2703,7 @@ html.dark .dropdown-surface :is(select, option) {
 
 .shell-topbar {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: space-between;
 }
 .shell-topbar-center {
@@ -2743,7 +2743,13 @@ html.dark .dropdown-surface :is(select, option) {
     margin: 0;
   }
   .shell-topbar [data-topbar-right-group] {
-    padding: 0 0 4px !important;
+    padding: 0 !important;
+  }
+}
+
+@container topbar-speed (max-width: 60px) {
+  .shell-metric-pill {
+    display: none !important;
   }
 }
 

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1555,19 +1555,17 @@ export function AppShell() {
         {/* Top bar: 3-zone segmented control bar */}
         <div ref={topBarRef} className="shell-topbar" style={{
           position: "relative",
-          display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
           flexShrink: 0,
           borderBottom: "1px solid var(--border)",
-          height: isMobile ? 44 : 36,
+          minHeight: isMobile ? 44 : 36,
           background: "var(--bg-panel)",
           padding: isMobile ? "0 4px" : "0 8px",
-          gap: 8,
+          gap: "0 8px",
           minWidth: 0,
         }}>
           {/* Left Zone: Utility group (sidebar, theme, language) & session controls (history, branches, system) */}
-          <div style={{ display: "flex", alignItems: "center", gap: 4, height: "100%", flexShrink: 0 }}>
+          <div className="shell-topbar-tools" style={{ display: "flex", alignItems: "center", gap: 4, height: isMobile ? 43 : 35, minWidth: 0, flexShrink: 0 }}>
             <button
               onClick={handleSidebarToggle}
               title={sidebarOpen ? t("appShell.hideSidebar") : t("appShell.showSidebar")}
@@ -1644,8 +1642,9 @@ export function AppShell() {
               <div
                 className="shell-topbar-center"
                 style={{
-                  flex: 1,
                   minWidth: 0,
+                  containerType: "inline-size",
+                  containerName: "breadcrumb",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -1754,8 +1753,7 @@ export function AppShell() {
               display: "flex",
               alignItems: "center",
               gap: 6,
-              height: "100%",
-              paddingRight: isMobile ? (rightPanelOpen ? 0 : 44) : rightPanelOpen ? 8 : 44,
+              paddingRight: rightPanelOpen ? 8 : 44,
               flexShrink: 0,
             }}
           >

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1752,9 +1752,14 @@ export function AppShell() {
               marginLeft: "auto",
               display: "flex",
               alignItems: "center",
+              justifyContent: "flex-end",
               gap: 6,
               paddingRight: rightPanelOpen ? 8 : 44,
-              flexShrink: 0,
+              minWidth: 0,
+              width: 200,
+              containerType: "inline-size",
+              containerName: "topbar-speed",
+              flexShrink: 1,
             }}
           >
 
@@ -1764,7 +1769,7 @@ export function AppShell() {
                 ? `${generationSpeed.current.toFixed(1)} t/s`
                 : null;
               const averageSpeedStr = generationSpeed?.average !== null && generationSpeed?.average !== undefined
-                ? `AVG ${generationSpeed.average.toFixed(1)} t/s`
+                ? `${generationSpeed.average.toFixed(1)} t/s`
                 : null;
               if (!currentSpeedStr && !averageSpeedStr) return null;
               const speedTitle = currentSpeedStr
@@ -1790,11 +1795,17 @@ export function AppShell() {
                     fontVariantNumeric: "tabular-nums",
                     whiteSpace: "nowrap",
                     cursor: "default",
-                    flexShrink: 0,
+                    minWidth: 0,
+                    overflow: "hidden",
+                    flexShrink: 1,
                   }}
                 >
-                  <Zap size={11} strokeWidth={2} aria-hidden="true" style={{ color: currentSpeedStr ? "var(--accent)" : "var(--text-dim)" }} />
-                  <span style={{ fontWeight: currentSpeedStr ? 600 : 400 }}>
+                  {currentSpeedStr ? (
+                    <Zap size={11} strokeWidth={2} aria-hidden="true" style={{ flexShrink: 0, color: "var(--accent)" }} />
+                  ) : (
+                    <span style={{ flexShrink: 0, color: "var(--text-dim)" }}>AVG</span>
+                  )}
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", fontWeight: currentSpeedStr ? 600 : 400 }}>
                     {currentSpeedStr ?? averageSpeedStr}
                   </span>
                 </div>

--- a/components/RightPanel.tsx
+++ b/components/RightPanel.tsx
@@ -162,8 +162,8 @@ export const RightPanel = memo(function RightPanel({
         }}
       >
         {/* Right panel toolbar: tabs + editor integrations (chat, path, explorer) */}
-        <div style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", height: 36 }}>
-          <div style={{ flex: 1, overflow: "hidden", minWidth: 0 }}>
+        <div className="right-panel-toolbar" style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", minHeight: isMobile ? 44 : 36, paddingRight: isMobile ? 44 : 36, flexWrap: isMobile ? "wrap" : "nowrap" }}>
+          <div style={{ flex: isMobile ? "1 0 100%" : 1, overflow: "hidden", minWidth: 0 }}>
             <TabBar
               tabs={fileTabs}
               activeTabId={rightView === "file" ? activeFileTabId ?? "" : ""}
@@ -206,11 +206,12 @@ export const RightPanel = memo(function RightPanel({
                 onClick={() => fileExplorerRef.current?.collapseAll()}
                 title={t("sessionSidebar.collapseExplorer")}
                 aria-label={t("sessionSidebar.collapseExplorer")}
-                style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 26, height: 26, padding: 0, background: "none", border: "none", borderRadius: "var(--radius-control)", color: "var(--text-dim)", cursor: "pointer" }}
+                style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 6, width: isMobile ? "auto" : 26, height: 26, padding: isMobile ? "0 8px" : 0, background: "none", border: "none", borderRadius: "var(--radius-control)", color: "var(--text-muted)", cursor: "pointer", fontSize: 11 }}
                 onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text)"; e.currentTarget.style.background = "var(--bg-hover)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.background = "none"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "none"; }}
               >
-                <ChevronsDownUp size={13} strokeWidth={2} aria-hidden="true" />
+                <ChevronsDownUp size={isMobile ? 16 : 13} strokeWidth={2} aria-hidden="true" style={{ flexShrink: 0 }} />
+                {isMobile && <span>{t("sessionSidebar.collapseExplorer")}</span>}
               </button>
               <button
                 aria-label={t("sessionSidebar.refreshExplorer")}

--- a/components/RightPanel.tsx
+++ b/components/RightPanel.tsx
@@ -152,7 +152,7 @@ export const RightPanel = memo(function RightPanel({
       {/* Right panel: file viewer — always mounted, width animated via CSS */}
       <div
         ref={rightPanelRef}
-        className={`right-panel-container${rightPanelOpen ? " right-panel-open" : " right-panel-closed"}${rightPanelWidth !== null ? " right-panel-custom-width" : ""}${rightPanelResizing ? " right-panel-resizing" : ""}`}
+        className={`right-panel-container${rightPanelOpen ? " right-panel-open" : " right-panel-closed"}${rightPanelResizing ? " right-panel-resizing" : ""}`}
         style={{
           display: "flex",
           flexDirection: "column",
@@ -162,8 +162,8 @@ export const RightPanel = memo(function RightPanel({
         }}
       >
         {/* Right panel toolbar: tabs + editor integrations (chat, path, explorer) */}
-        <div className="right-panel-toolbar" style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", minHeight: isMobile ? 44 : 36, paddingRight: isMobile ? 44 : 36, flexWrap: isMobile ? "wrap" : "nowrap" }}>
-          <div style={{ flex: isMobile ? "1 0 100%" : 1, overflow: "hidden", minWidth: 0 }}>
+        <div className="right-panel-toolbar" style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", minHeight: isMobile ? 44 : 36, paddingRight: isMobile ? 44 : 36, flexWrap: "wrap" }}>
+          <div style={{ flex: isMobile ? "1 0 100%" : "1 1 160px", overflow: "hidden", minWidth: 0 }}>
             <TabBar
               tabs={fileTabs}
               activeTabId={rightView === "file" ? activeFileTabId ?? "" : ""}


### PR DESCRIPTION
## Summary
- Center the workspace/session breadcrumb over the conversation column, not the gap between unequal control groups; hide it when sidebars leave insufficient room.
- Keep the mobile file-panel toggle clear of generation speed. Match Explorer/Git tabs and toggle at 44px, with a separate touch-sized Explorer action row and the existing localized collapse label on mobile.
- Keep saved-width file panels inside narrower windows. Size their contents from the actual panel rather than an independent viewport width, and wrap toolbars when space is tight. This also fixes clipping at non-default interface scales.

Focused port onto current upstream main: no downstream deployment, navigation, or workspace-selector patch stack is included.

## Verification
- npm run typecheck and npm run lint passed; npm test: **630 passed, 1 skipped, 0 failed**.
- Real Chromium: **56 passing width/scale combinations** across 641, 700, 760, 859, 860, 861, and 1024px at all four interface scales, both with Markdown selected and with Explorer selected while the Markdown tab stays open. Content stays inside the panel; toolbar buttons remain hit-testable and clear of the toggle.
- Saved ~600px panel at a 641px viewport shrinks to available space without clipping. Also verified 320, 390, and 640px mobile layouts; mobile tabs/toggle are 44px and action targets are 40px.
- Search opens; expanding then collapsing leaves zero expanded folders; Upload opens the multi-file chooser (cancelled without uploading).
- Desktop at 1440px, sidebar open/closed: breadcrumb center error reduced from about 35px to less than 0.01px. The follow-up below replaces the header wrapping fallback with a single-row speed display.
- Condensed adversarial review completed, including the intermediate-width correction; no blockers.

Screenshots use a synthetic session and workspace, not private conversation data. The fixture has no model credentials; no live prompts were sent.

## Mobile Explorer — light
| Before | After |
| --- | --- |
| ![Before, light](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/mobile-before-light.png) | ![After, light](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/mobile-after-light.png) |

## Mobile Explorer — dark
| Before | After |
| --- | --- |
| ![Before, dark](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/mobile-before-dark.png) | ![After, dark](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/mobile-after-dark.png) |

<details>
<summary>Desktop breadcrumb comparison — light and dark</summary>

### Light, sidebar closed
Before:
![Desktop before, light](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/desktop-before-light.png)
After:
![Desktop after, light](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/desktop-after-light.png)

### Dark, sidebar open
Before:
![Desktop before, dark](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/desktop-before-dark.png)
After:
![Desktop after, dark](https://raw.githubusercontent.com/andrebrait/ompweb/pr-assets/header-layout-156c26c/desktop-after-dark.png)

</details>