### PR TITLE
fix: keep provider navigation and save controls in flow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2334,6 +2334,8 @@ html.dark .dropdown-surface :is(select, option) {
 /* Provider Sub-navigation & Cards */
 .providers-segmented {
   display: inline-flex;
+  flex-wrap: wrap;
+  max-width: 100%;
   align-items: stretch;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
@@ -2354,7 +2356,8 @@ html.dark .dropdown-surface :is(select, option) {
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   transition: background var(--dur-fast) var(--ease-out-warm), color var(--dur-fast) var(--ease-out-warm);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2334,14 +2334,17 @@ html.dark .dropdown-surface :is(select, option) {
 /* Provider Sub-navigation & Cards */
 .providers-segmented {
   display: inline-flex;
-  flex-wrap: wrap;
-  max-width: 100%;
+  flex-wrap: nowrap;
   align-items: stretch;
+  width: max-content;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--bg-panel);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   margin-bottom: 24px;
+  box-sizing: border-box;
 }
 
 .providers-segmented-btn {
@@ -2356,8 +2359,8 @@ html.dark .dropdown-surface :is(select, option) {
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  white-space: normal;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
+  flex-shrink: 0;
   transition: background var(--dur-fast) var(--ease-out-warm), color var(--dur-fast) var(--ease-out-warm);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2361,10 +2361,6 @@ html.dark .dropdown-surface :is(select, option) {
   transition: background var(--dur-fast) var(--ease-out-warm), color var(--dur-fast) var(--ease-out-warm);
 }
 
-.providers-segmented-btn + .providers-segmented-btn {
-  border-left: 1px solid var(--border);
-}
-
 .providers-segmented-btn:hover {
   background: var(--bg-hover);
   color: var(--text);

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -1983,13 +1983,15 @@ export function ModelsConfig({ onClose, onSelectTab, onSaved, embedded = false }
           </div>
         )}
 
-        {/* Footer for saving models.yml */}
+        {/* Save controls */}
         {(subTab === "custom" || !embedded) && (
-          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 10, padding: "12px 18px", borderTop: "1px solid var(--border)", background: "var(--bg-panel)", borderRadius: "0 0 var(--radius-card) var(--radius-card)", flexShrink: 0, marginTop: 16 }}>
-            <div style={{ flex: "1 1 220px", minWidth: 0, overflowWrap: "anywhere", fontSize: 12, color: saveError ? "var(--status-error)" : "var(--text-muted)" }}>
-              {saveError ? saveError : <code>~/.omp/agent/models.yml</code>}
-            </div>
-            <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10, marginLeft: "auto" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 10, flexWrap: "wrap", marginTop: 16, flexShrink: 0 }}>
+            {saveError && (
+              <div style={{ flex: "1 1 220px", minWidth: 0, overflowWrap: "anywhere", fontSize: 12, color: "var(--status-error)" }}>
+                {saveError}
+              </div>
+            )}
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               <button onClick={() => loadConfig()} disabled={loading} style={{ padding: "6px 14px", background: "none", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-muted)", cursor: "pointer", fontSize: 12.5 }}>
                 {t("modelsConfig.cancel")}
               </button>

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -130,12 +130,12 @@ function ProviderDetail({ name, provider, onChange, onRename, onDelete }: {
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       {/* Hero Provider Header Card */}
       <div style={{ padding: "14px 16px", border: "1px solid var(--border)", borderRadius: "var(--radius-card)", background: "var(--bg-panel)", display: "flex", flexDirection: "column", gap: 10, boxShadow: "var(--shadow-card)" }}>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flex: "1 1 220px", minWidth: 0 }}>
             <div style={{ width: 36, height: 36, borderRadius: "var(--radius-control)", background: "var(--bg-subtle)", border: "1px solid var(--border)", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
               <ProviderIcon id={name} size={20} />
             </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0, overflowWrap: "anywhere" }}>
               <div style={{ fontSize: 15, fontWeight: 700, fontFamily: "var(--font-mono)", color: "var(--text)" }}>{name}</div>
               <div style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>{hostName}</div>
             </div>
@@ -1860,15 +1860,15 @@ export function ModelsConfig({ onClose, onSelectTab, onSaved, embedded = false }
                         const models = pData.models ?? [];
                         return (
                           <div key={pName} className="settings-card" style={{ flexDirection: "column", alignItems: "stretch", gap: 12 }}>
-                            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-                              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                            <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+                              <div style={{ display: "flex", alignItems: "center", gap: 10, flex: "1 1 220px", minWidth: 0 }}>
                                 <ProviderIcon id={pName} size={22} />
-                                <div>
+                                <div style={{ minWidth: 0, overflowWrap: "anywhere" }}>
                                   <div style={{ fontSize: 13.5, fontWeight: 700, fontFamily: "var(--font-mono)", color: "var(--text)" }}>{pName}</div>
                                   <div style={{ fontSize: 11.5, color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>{pData.baseUrl || t("modelsConfig.defaultEndpoint")}</div>
                                 </div>
                               </div>
-                              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                              <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 6 }}>
                                 <button
                                   type="button"
                                   onClick={() => addModel(pName)}

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -1805,8 +1805,8 @@ export function ModelsConfig({ onClose, onSelectTab, onSaved, embedded = false }
                 </div>
               ) : (
                 <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-                  <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
-                    <div>
+                  <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+                    <div style={{ flex: "1 1 220px", minWidth: 0, overflowWrap: "anywhere" }}>
                       <div style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>{t("modelsConfig.customProviders")}</div>
                       <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 3 }}>
                         Custom endpoints, local Ollama / vLLM models, or reverse proxies defined in <code style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>~/.omp/agent/models.yml</code>.
@@ -1985,11 +1985,11 @@ export function ModelsConfig({ onClose, onSelectTab, onSaved, embedded = false }
 
         {/* Footer for saving models.yml */}
         {(subTab === "custom" || !embedded) && (
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, padding: "12px 18px", borderTop: "1px solid var(--border)", background: "var(--bg-panel)", borderRadius: "0 0 var(--radius-card) var(--radius-card)", flexShrink: 0, marginTop: 16 }}>
-            <div style={{ fontSize: 12, color: saveError ? "var(--status-error)" : "var(--text-muted)" }}>
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 10, padding: "12px 18px", borderTop: "1px solid var(--border)", background: "var(--bg-panel)", borderRadius: "0 0 var(--radius-card) var(--radius-card)", flexShrink: 0, marginTop: 16 }}>
+            <div style={{ flex: "1 1 220px", minWidth: 0, overflowWrap: "anywhere", fontSize: 12, color: saveError ? "var(--status-error)" : "var(--text-muted)" }}>
               {saveError ? saveError : <code>~/.omp/agent/models.yml</code>}
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10, marginLeft: "auto" }}>
               <button onClick={() => loadConfig()} disabled={loading} style={{ padding: "6px 14px", background: "none", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-muted)", cursor: "pointer", fontSize: 12.5 }}>
                 {t("modelsConfig.cancel")}
               </button>


### PR DESCRIPTION
## Summary
- keep provider and OMP System navigation in one horizontally scrollable row on narrow screens
- prevent provider labels from wrapping or clipping
- keep Save/Cancel controls in normal document flow with inline save errors
- remove redundant Save banner/path presentation while retaining the provider description path

## Verification
- npm test
- npm run build
- npm run typecheck
- npm run lint
- browser verification at 320px confirmed no document overflow, scrollable navigation rows, and non-overlapping in-flow Save controls

No Copilot or CodeRabbit review requested per maintainer instruction.