### PR TITLE
Scope Select All to active content with opt-in native-menu support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 
 ## Unreleased
 
+### Added
+
+- Scope Ctrl+A / Cmd+A to the selected message, currently loaded chat, or active file contents instead of the whole page. Text fields retain native Select All behavior; browser-menu commands and embedded viewers remain browser-controlled.
+
 ### Fixes & Improvements
 
 - Keep composer controls on one line, with equally sized Send, Stop, and Queue buttons and model names truncating before short effort labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 ### Added
 
 - Scope Ctrl+A / Cmd+A to the selected message, currently loaded chat, or active file contents instead of the whole page. Message selection includes collapsed extension previews and expanded details without toolbar labels. Newer pane focus takes precedence over retained child selections. Text fields and IME composition retain native behavior; browser-menu commands and embedded viewers remain browser-controlled.
+- Add an off-by-default **Scope native Select All (experimental)** switch in Settings → Interface & Behavior. The per-browser preference narrows whole-page selections from native menus while leaving keyboard scoping independent. Disable it if browser selection handles or menus behave unexpectedly; intentional whole-page selections can also be narrowed.
 
 ### Fixes & Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 
 ### Added
 
-- Scope Ctrl+A / Cmd+A to the selected message, currently loaded chat, or active file contents instead of the whole page. Text fields retain native Select All behavior; browser-menu commands and embedded viewers remain browser-controlled.
+- Scope Ctrl+A / Cmd+A to the selected message, currently loaded chat, or active file contents instead of the whole page. Message selection includes collapsed extension previews and expanded details without toolbar labels. Newer pane focus takes precedence over retained child selections. Text fields and IME composition retain native behavior; browser-menu commands and embedded viewers remain browser-controlled.
 
 ### Fixes & Improvements
 

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -82,6 +82,7 @@ const RightPanel = dynamic(() => import("./RightPanel").then((m) => m.RightPanel
 
 const TOOL_CALLS_COLLAPSED_STORAGE_KEY = "omp-web:tool-calls-collapsed";
 const PROVIDER_USAGE_VISIBLE_STORAGE_KEY = "omp-web:provider-usage-visible";
+const NATIVE_SELECT_ALL_STORAGE_KEY = "omp-web:scope-native-select-all";
 
 const CommandPalette = dynamic(() => import("./CommandPalette").then((m) => m.CommandPalette), {
   ssr: false,
@@ -124,6 +125,7 @@ export function AppShell() {
   const [sidebarWidth, setSidebarWidth] = useState<number>(SIDEBAR_DEFAULT_WIDTH);
   const [toolCallsDefaultCollapsed, setToolCallsDefaultCollapsed] = useState(true);
   const [providerUsageVisible, setProviderUsageVisible] = useState(true);
+  const [scopeNativeSelectAll, setScopeNativeSelectAll] = useState(false);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   // Active drag handlers so an unmount mid-drag can detach them.
   const sidebarResizeHandlersRef = useRef<{ onMove: (ev: MouseEvent) => void; onUp: () => void } | null>(null);
@@ -135,6 +137,7 @@ export function AppShell() {
     try {
       setToolCallsDefaultCollapsed(window.localStorage.getItem(TOOL_CALLS_COLLAPSED_STORAGE_KEY) !== "false");
       setProviderUsageVisible(window.localStorage.getItem(PROVIDER_USAGE_VISIBLE_STORAGE_KEY) !== "false");
+      setScopeNativeSelectAll(window.localStorage.getItem(NATIVE_SELECT_ALL_STORAGE_KEY) === "true");
     } catch {
       // Keep the compact default when storage is unavailable.
     }
@@ -151,6 +154,14 @@ export function AppShell() {
     setProviderUsageVisible(visible);
     try {
       window.localStorage.setItem(PROVIDER_USAGE_VISIBLE_STORAGE_KEY, String(visible));
+    } catch {
+      // The preference still applies for this page load.
+    }
+  }, []);
+  const handleScopeNativeSelectAllChange = useCallback((enabled: boolean) => {
+    setScopeNativeSelectAll(enabled);
+    try {
+      window.localStorage.setItem(NATIVE_SELECT_ALL_STORAGE_KEY, String(enabled));
     } catch {
       // The preference still applies for this page load.
     }
@@ -1101,6 +1112,7 @@ export function AppShell() {
   useGlobalKeyboardShortcuts({
     onNewSession: (cwd: string) => handleNewSession(`kb-${Date.now()}`, cwd),
     activeCwd,
+    scopeNativeSelectAll,
   });
 
   // Client-built transient SessionInfo (new session / fork) lacks the
@@ -1670,6 +1682,8 @@ export function AppShell() {
             onToolCallsDefaultCollapsedChange={handleToolCallsDefaultCollapsedChange}
             providerUsageVisible={providerUsageVisible}
             onProviderUsageVisibleChange={handleProviderUsageVisibleChange}
+            scopeNativeSelectAll={scopeNativeSelectAll}
+            onScopeNativeSelectAllChange={handleScopeNativeSelectAllChange}
             cwd={activeCwd ?? selectedSession?.cwd ?? newSessionCwd}
             sessionId={selectedSession?.id ?? null}
             onModelsSaved={() => setModelsRefreshKey((k) => k + 1)}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1165,7 +1165,7 @@ export function ChatWindow({ session, newSessionCwd, newSessionWorkspace, toolCa
         {/* Hide the Firefox scrollbar on desktop only: ChatMinimap provides the
             position indicator there, but on mobile there is no minimap and
             users need the scrollbar (Chrome's overlay scrollbar still shows). */}
-        <div ref={scrollContainerRef} className={`flex-1 overflow-y-auto pt-6` + (isMobile ? "" : " [scrollbar-width:none] [&::-webkit-scrollbar]:hidden")}>
+        <div ref={scrollContainerRef} data-selection-scope="chat" tabIndex={-1} className={`flex-1 overflow-y-auto pt-6` + (isMobile ? "" : " [scrollbar-width:none] [&::-webkit-scrollbar]:hidden")}>
           <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
             <div style={{ maxWidth: isMobile ? CHAT_COLUMN_MAX_WIDTH : CHAT_COLUMN_MAX_WIDTH_DESKTOP, margin: "0 auto" }}>
               <ExtensionStatusBar statuses={extensionStatuses} />

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -1160,7 +1160,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionL
       </div>
 
       {/* Content area */}
-      <div ref={contentRef} className="file-viewer-content" style={{ flex: 1, overflow: "auto", background: "var(--bg)" }}>
+      <div ref={contentRef} data-selection-scope="document" tabIndex={-1} className="file-viewer-content" style={{ flex: 1, overflow: "auto", background: "var(--bg)" }}>
         {displayMode === "diff" && hasGitDiff ? (
           <DiffView patch={gitDiff.patch!} />
         ) : isHtml && displayMode === "preview" ? (

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1303,7 +1303,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
 
   return (
     <div style={{ marginBottom: 8, display: "flex", justifyContent: "center" }}>
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0, width: "100%", maxWidth: 640 }}>
+      <div data-selection-scope="message" tabIndex={-1} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0, width: "100%", maxWidth: 640 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8, width: "100%" }}>
           <div style={{ flex: 1, height: 1, background: "var(--border)", opacity: 0.55 }} />
           <button
@@ -1312,6 +1312,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
             aria-expanded={expanded}
             aria-label={expanded ? t("messageView.collapse") : t("messageView.expand")}
             style={{
+              userSelect: expanded ? "none" : undefined,
               display: "inline-flex",
               alignItems: "center",
               gap: 6,
@@ -1341,7 +1342,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
           </button>
           <div style={{ flex: 1, height: 1, background: "var(--border)", opacity: 0.55 }} />
         </div>
-        {time ? <span style={{ marginTop: 2, color: "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums", opacity: 0.75 }}>{time}</span> : null}
+        {time ? <span style={{ userSelect: "none", marginTop: 2, color: "var(--text-dim)", fontSize: 10, fontVariantNumeric: "tabular-nums", opacity: 0.75 }}>{time}</span> : null}
         {expanded ? (
           <div
             style={{
@@ -1353,7 +1354,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
               background: "var(--bg-subtle)",
             }}
           >
-            <div data-selection-scope="message" tabIndex={-1} style={{ padding: "8px 10px" }}>
+            <div style={{ padding: "8px 10px" }}>
               {images.length > 0 && (
                 <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: cleanText ? 8 : 0 }}>
                   {images.map((img, i) => {
@@ -1380,6 +1381,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
             </div>
             <div
               style={{
+                userSelect: "none",
                 display: "flex",
                 alignItems: "center",
                 gap: 8,
@@ -1493,6 +1495,8 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
   return (
     <div style={{ marginBottom: 16 }}>
       <div
+        data-selection-scope="message"
+        tabIndex={-1}
         style={{
           border: "1px solid var(--border)",
           borderRadius: 8,
@@ -1502,6 +1506,7 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
       >
         <div
           style={{
+            userSelect: "none",
             display: "flex",
             alignItems: "center",
             gap: 8,
@@ -1519,7 +1524,7 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
         </div>
 
         {contentExpanded ? (
-          <div data-selection-scope="message" tabIndex={-1} style={{ padding: "6px 9px" }}>
+          <div style={{ padding: "6px 9px" }}>
             {images.length > 0 && (
               <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: displayText ? 8 : 0 }}>
                 {images.map((img, i) => {
@@ -1559,6 +1564,7 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
 
         <div
           style={{
+            userSelect: "none",
             display: "flex",
             alignItems: "center",
             gap: 8,

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1329,7 +1329,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
             }}
           >
             <EyeOff size={12} strokeWidth={1.8} style={{ flexShrink: 0, opacity: 0.85 }} />
-            <span style={{ fontFamily: "var(--font-mono)", fontWeight: 650, letterSpacing: "0.01em", color: "var(--text-muted)", fontSize: 11 }}>
+            <span style={{ userSelect: "none", fontFamily: "var(--font-mono)", fontWeight: 650, letterSpacing: "0.01em", color: "var(--text-muted)", fontSize: 11 }}>
               {label}
             </span>
             {preview ? (

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -333,6 +333,8 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
       <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", maxWidth: "85%", minWidth: 0 }}>
         <div
           className="chat-message-card"
+          data-selection-scope="message"
+          tabIndex={-1}
           style={{
             maxWidth: "100%",
             minWidth: 0,
@@ -665,7 +667,7 @@ function AssistantMessageView({
         })()}
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <div data-selection-scope="message" tabIndex={-1} style={{ display: "flex", flexDirection: "column", gap: 3 }}>
         {groupAdjacentBlocks(blockItems).map((group, groupIdx) => {
           if (group.type === "single") {
             const { block, originalIndex } = group.item;
@@ -1193,7 +1195,7 @@ function CompactionMessageView({ message }: { message: CustomMessage }) {
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, fontWeight: 650 }}>{t("messageView.compactionLabel")}</span>
           {time && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
         </div>
-        <div style={{ padding: "11px 13px 12px" }}>
+        <div data-selection-scope="message" tabIndex={-1} style={{ padding: "11px 13px 12px" }}>
           <div style={{ color: "var(--text)", fontSize: 15, fontWeight: 700, lineHeight: 1.35 }}>{t("messageView.conversationCompacted")}</div>
           {(method || (tokensBefore !== null && tokensAfter !== null)) && (
             <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
@@ -1351,7 +1353,7 @@ function HiddenExtensionView({ message, cwd, onOpenFile }: { message: CustomMess
               background: "var(--bg-subtle)",
             }}
           >
-            <div style={{ padding: "8px 10px" }}>
+            <div data-selection-scope="message" tabIndex={-1} style={{ padding: "8px 10px" }}>
               {images.length > 0 && (
                 <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: cleanText ? 8 : 0 }}>
                   {images.map((img, i) => {
@@ -1517,7 +1519,7 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
         </div>
 
         {contentExpanded ? (
-          <div style={{ padding: "6px 9px" }}>
+          <div data-selection-scope="message" tabIndex={-1} style={{ padding: "6px 9px" }}>
             {images.length > 0 && (
               <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: displayText ? 8 : 0 }}>
                 {images.map((img, i) => {
@@ -1747,7 +1749,7 @@ function BashExecutionView({ message, sessionId }: { message: BashExecutionMessa
     : null;
 
   return (
-    <div style={{ margin: "6px 0" }}>
+    <div data-selection-scope="message" tabIndex={-1} style={{ margin: "6px 0" }}>
       <ToolCallBlock block={block} result={result} />
       {downloadUrl && (
         <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 6 }}>

--- a/components/SettingsConfig.tsx
+++ b/components/SettingsConfig.tsx
@@ -130,6 +130,7 @@ const SETTING_INDEX: SettingIndexEntry[] = [
   // Interface & Behavior
   { id: "completion-sound", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.completionSound", descKey: "settingsConfig.completionSoundDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Completion sound", fallbackDesc: "Play a tone when the agent completes a run.", scope: "UI" },
   { id: "keep-tool-calls-collapsed", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.keepToolCallsCollapsed", descKey: "settingsConfig.keepToolCallsCollapsedDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Keep tool calls collapsed", fallbackDesc: "Show only compact headers while tools execute.", scope: "UI" },
+  { id: "scope-native-select-all", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.scopeNativeSelectAll", descKey: "settingsConfig.scopeNativeSelectAllDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Scope native Select All (experimental)", fallbackDesc: "Limit whole-page selections from browser or touch menus to the active message, chat, or file. May also narrow deliberate whole-page selections. Turn off if selection handles or menus misbehave. Keyboard shortcuts are unaffected.", scope: "UI" },
   { id: "provider-usage", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.providerUsage", descKey: "settingsConfig.providerUsageDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Provider usage limits", fallbackDesc: "Show provider usage in the sidebar, above Settings.", scope: "UI" },
   { id: "chat-font-size", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.chatFontSize", descKey: "settingsConfig.chatFontSizeDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Chat Font Size", fallbackDesc: "Adjust text size for conversation messages, code blocks, and markdown output.", scope: "UI" },
   { id: "ui-scale", tab: "general", sectionKey: "settingsConfig.interfaceBehavior", labelKey: "settingsConfig.uiScale", descKey: "settingsConfig.uiScaleDesc", fallbackSection: "Interface & Behavior", fallbackLabel: "Interface Scale", fallbackDesc: "Adjust overall UI zoom and display density across sidebars, dialogs, buttons, and toolbars.", scope: "UI" },
@@ -355,12 +356,14 @@ function NativeSetting({ label, description, scope, searchId, children }: { labe
   );
 }
 
-export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCallsDefaultCollapsedChange, providerUsageVisible, onProviderUsageVisibleChange, cwd, sessionId, onModelsSaved, onPluginsReloaded, appUpdate, onRefreshAppUpdate, onOmpUpdateAvailabilityChange, onRequestAppUpdate, onSelectTab, onClose }: {
+export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCallsDefaultCollapsedChange, providerUsageVisible, onProviderUsageVisibleChange, scopeNativeSelectAll, onScopeNativeSelectAllChange, cwd, sessionId, onModelsSaved, onPluginsReloaded, appUpdate, onRefreshAppUpdate, onOmpUpdateAvailabilityChange, onRequestAppUpdate, onSelectTab, onClose }: {
   activeTab: SettingsTab;
   toolCallsDefaultCollapsed: boolean;
   onToolCallsDefaultCollapsedChange: (collapsed: boolean) => void;
   providerUsageVisible: boolean;
   onProviderUsageVisibleChange: (visible: boolean) => void;
+  scopeNativeSelectAll: boolean;
+  onScopeNativeSelectAllChange: (enabled: boolean) => void;
   cwd: string | null;
   sessionId: string | null;
   onModelsSaved: () => void;
@@ -759,6 +762,9 @@ export function SettingsConfig({ activeTab, toolCallsDefaultCollapsed, onToolCal
                 <div style={{ display: "flex", flexDirection: "column", gap: 10, width: "100%" }}>
                   <NativeSetting searchId="keep-tool-calls-collapsed" label={t("settingsConfig.keepToolCallsCollapsed")} description={t("settingsConfig.keepToolCallsCollapsedDesc")} scope="UI">
                     <ToggleSwitch checked={toolCallsDefaultCollapsed} onChange={onToolCallsDefaultCollapsedChange} />
+                  </NativeSetting>
+                  <NativeSetting searchId="scope-native-select-all" label={t("settingsConfig.scopeNativeSelectAll")} description={t("settingsConfig.scopeNativeSelectAllDesc")} scope="UI">
+                    <ToggleSwitch checked={scopeNativeSelectAll} onChange={onScopeNativeSelectAllChange} />
                   </NativeSetting>
                   <NativeSetting searchId="completion-sound" label={t("settingsConfig.completionSound")} description={t("settingsConfig.completionSoundDesc")} scope="UI">
                     <ToggleSwitch

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -25,6 +25,8 @@ interface UseGlobalKeyboardShortcutsOptions {
   onNewSession?: (cwd: string) => void;
   /** The currently selected project directory (sidebar cwd). */
   activeCwd?: string | null;
+  /** Best-effort native-menu selection scoping; keyboard scoping is independent. */
+  scopeNativeSelectAll?: boolean;
 }
 
 /**
@@ -43,15 +45,105 @@ interface UseGlobalKeyboardShortcutsOptions {
 export function useGlobalKeyboardShortcuts(
   options: UseGlobalKeyboardShortcutsOptions,
 ): void {
-  const { onNewSession, activeCwd } = options;
+  const { onNewSession, activeCwd, scopeNativeSelectAll = false } = options;
 
   useEffect(() => {
     let interactionTarget: Element | null = null;
+    let nativeScope: HTMLElement | null = null;
+    let pointerDown = false;
+    let composing = false;
     const scopeFor = (node: Node | null): HTMLElement | null =>
       (node instanceof Element ? node : node?.parentElement)?.closest<HTMLElement>("[data-selection-scope]") ?? null;
     const trackInteraction = (event: Event) => {
       interactionTarget = event.target instanceof Element ? event.target : null;
+      if (scopeNativeSelectAll) {
+        if (event instanceof PointerEvent) pointerDown = event.type === "pointerdown" && event.button === 0;
+        nativeScope = scopeFor(interactionTarget);
+        if (event.type === "contextmenu") rememberSelectionScope();
+      }
     };
+    const selectContents = (scope: HTMLElement) => {
+      const range = document.createRange();
+      range.selectNodeContents(scope);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    };
+    const textSelectable = (element: HTMLElement) => {
+      if (!element.checkVisibility({ checkVisibilityCSS: true })) return false;
+      for (let parent: HTMLElement | null = element; parent; parent = parent.parentElement) {
+        const style = getComputedStyle(parent);
+        if (style.userSelect === "none") return false;
+        // Closed sidebars stay mounted at zero width; checkVisibility alone
+        // does not account for their clipping.
+        if (style.overflowX !== "visible" || style.overflowY !== "visible") {
+          const rect = parent.getBoundingClientRect();
+          if ((style.overflowX !== "visible" && rect.width === 0)
+            || (style.overflowY !== "visible" && rect.height === 0)) return false;
+        }
+      }
+      return true;
+    };
+    const scopeAvailable = (scope: HTMLElement | null): scope is HTMLElement =>
+      !!scope?.isConnected && textSelectable(scope)
+      && !scope.closest("[inert], [aria-hidden='true']");
+    const editorFocused = () => {
+      const element = document.activeElement;
+      return !!element?.matches("input, textarea, select, iframe")
+        || (element instanceof HTMLElement && element.isContentEditable);
+    };
+    const rememberSelectionScope = () => {
+      const activeScope = scopeFor(interactionTarget ?? document.activeElement);
+      const selection = window.getSelection();
+      const selectedScope = selection?.rangeCount === 1
+        ? scopeFor(selection.getRangeAt(0).commonAncestorContainer) : null;
+      nativeScope = activeScope && selectedScope?.contains(activeScope) ? selectedScope : activeScope;
+    };
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount !== 1) {
+        rememberSelectionScope();
+        return;
+      }
+      // Native selections crossing shadow roots can appear collapsed through
+      // getRangeAt(), even while the entire page is visibly selected.
+      let range = selection.getRangeAt(0);
+      const composed = selection.getComposedRanges?.()[0];
+      if (composed) {
+        range = document.createRange();
+        range.setStart(composed.startContainer, composed.startOffset);
+        range.setEnd(composed.endContainer, composed.endOffset);
+      }
+      if (range.collapsed || scopeFor(range.commonAncestorContainer)) {
+        rememberSelectionScope();
+        return;
+      }
+      if (pointerDown || composing || editorFocused() || !scopeAvailable(nativeScope)) return;
+      // Only correct a range covering both ends of the page's selectable text.
+      // Ordinary partial/cross-pane selections never reach the replacement below.
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+          const element = node.parentElement;
+          if (!node.textContent?.trim() || !element || element.closest("script, style, noscript, input, textarea")
+            || !textSelectable(element)) return NodeFilter.FILTER_REJECT;
+          const textRange = document.createRange();
+          textRange.selectNodeContents(node);
+          return textRange.getClientRects().length ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+        },
+      });
+      const first = walker.nextNode();
+      walker.currentNode = document.body;
+      const last = walker.lastChild();
+      if (first && last && range.comparePoint(first, 0) === 0
+        && range.comparePoint(last, last.textContent?.length ?? 0) === 0) {
+        // No native Select All intent event exists: a deliberate whole-page
+        // selection is indistinguishable. This is why the fallback is opt-in.
+        selectContents(nativeScope);
+      }
+    };
+    const onPointerEnd = () => { pointerDown = false; };
+    const onCompositionStart = () => { composing = true; };
+    const onCompositionEnd = () => { composing = false; };
     const selectAll = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.isComposing || event.keyCode === 229 || event.key.toLowerCase() !== "a"
         || (!event.ctrlKey && !event.metaKey) || event.altKey || event.shiftKey) return;
@@ -76,24 +168,35 @@ export function useGlobalKeyboardShortcuts(
           scope = selectedScope;
         }
       }
-      if (!scope?.isConnected || !scope.checkVisibility({ checkVisibilityCSS: true })
-        || scope.closest("[inert], [aria-hidden='true']")) return;
-
-      const range = document.createRange();
-      range.selectNodeContents(scope);
+      if (!scopeAvailable(scope)) return;
       event.preventDefault();
-      selection.removeAllRanges();
-      selection.addRange(range);
+      selectContents(scope);
     };
     document.addEventListener("pointerdown", trackInteraction, true);
     document.addEventListener("focusin", trackInteraction, true);
     window.addEventListener("keydown", selectAll);
+    if (scopeNativeSelectAll) {
+      document.addEventListener("contextmenu", trackInteraction, true);
+      document.addEventListener("pointerup", onPointerEnd, true);
+      document.addEventListener("pointercancel", onPointerEnd, true);
+      document.addEventListener("compositionstart", onCompositionStart, true);
+      document.addEventListener("compositionend", onCompositionEnd, true);
+      document.addEventListener("selectionchange", onSelectionChange);
+    }
     return () => {
       document.removeEventListener("pointerdown", trackInteraction, true);
       document.removeEventListener("focusin", trackInteraction, true);
       window.removeEventListener("keydown", selectAll);
+      if (scopeNativeSelectAll) {
+        document.removeEventListener("contextmenu", trackInteraction, true);
+        document.removeEventListener("pointerup", onPointerEnd, true);
+        document.removeEventListener("pointercancel", onPointerEnd, true);
+        document.removeEventListener("compositionstart", onCompositionStart, true);
+        document.removeEventListener("compositionend", onCompositionEnd, true);
+        document.removeEventListener("selectionchange", onSelectionChange);
+      }
     };
-  }, []);
+  }, [scopeNativeSelectAll]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -33,6 +33,7 @@ interface UseGlobalKeyboardShortcutsOptions {
  * Shortcuts handled here:
  *   Esc          – stop the running agent (via module-level abort handler)
  *   Ctrl+Alt+N   – create a new session in the active project directory
+ *   Ctrl/Cmd+A   – select the active message, transcript, or file contents
  *
  * Note: Esc inside <textarea> or <input> is deliberately NOT handled here.
  * ChatInput manages its own Esc logic (closing slash / @ file menus, stopping
@@ -43,6 +44,56 @@ export function useGlobalKeyboardShortcuts(
   options: UseGlobalKeyboardShortcutsOptions,
 ): void {
   const { onNewSession, activeCwd } = options;
+
+  useEffect(() => {
+    let interactionTarget: Element | null = null;
+    const scopeFor = (node: Node | null): HTMLElement | null =>
+      (node instanceof Element ? node : node?.parentElement)?.closest<HTMLElement>("[data-selection-scope]") ?? null;
+    const trackInteraction = (event: Event) => {
+      interactionTarget = event.target instanceof Element ? event.target : null;
+    };
+    const selectAll = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing || event.key.toLowerCase() !== "a"
+        || (!event.ctrlKey && !event.metaKey) || event.altKey || event.shiftKey) return;
+
+      const target = event.target;
+      if (target instanceof Element && (
+        target.closest("input, textarea, select, iframe")
+        || (target instanceof HTMLElement && target.isContentEditable)
+      )) return;
+
+      const activeScope = scopeFor(interactionTarget ?? document.activeElement);
+      // Moving outside a content region must not revive an old text selection.
+      if (interactionTarget && !activeScope) return;
+      const selection = window.getSelection();
+      if (!selection) return;
+      let scope = activeScope;
+      if (selection.rangeCount && !selection.isCollapsed) {
+        const selectedScope = scopeFor(selection.getRangeAt(0).commonAncestorContainer);
+        // A range spanning messages belongs to their enclosing transcript.
+        // A stale range in another pane must not override the latest interaction.
+        if (selectedScope && (!activeScope || selectedScope.contains(activeScope) || activeScope.contains(selectedScope))) {
+          scope = selectedScope;
+        }
+      }
+      if (!scope?.isConnected || !scope.checkVisibility({ checkVisibilityCSS: true })
+        || scope.closest("[inert], [aria-hidden='true']")) return;
+
+      const range = document.createRange();
+      range.selectNodeContents(scope);
+      event.preventDefault();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+    document.addEventListener("pointerdown", trackInteraction, true);
+    document.addEventListener("focusin", trackInteraction, true);
+    window.addEventListener("keydown", selectAll);
+    return () => {
+      document.removeEventListener("pointerdown", trackInteraction, true);
+      document.removeEventListener("focusin", trackInteraction, true);
+      window.removeEventListener("keydown", selectAll);
+    };
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -53,7 +53,7 @@ export function useGlobalKeyboardShortcuts(
       interactionTarget = event.target instanceof Element ? event.target : null;
     };
     const selectAll = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.isComposing || event.key.toLowerCase() !== "a"
+      if (event.defaultPrevented || event.isComposing || event.keyCode === 229 || event.key.toLowerCase() !== "a"
         || (!event.ctrlKey && !event.metaKey) || event.altKey || event.shiftKey) return;
 
       const target = event.target;
@@ -71,8 +71,8 @@ export function useGlobalKeyboardShortcuts(
       if (selection.rangeCount && !selection.isCollapsed) {
         const selectedScope = scopeFor(selection.getRangeAt(0).commonAncestorContainer);
         // A range spanning messages belongs to their enclosing transcript.
-        // A stale range in another pane must not override the latest interaction.
-        if (selectedScope && (!activeScope || selectedScope.contains(activeScope) || activeScope.contains(selectedScope))) {
+        // A retained child selection must not override newer enclosing-pane focus.
+        if (selectedScope && (!activeScope || selectedScope.contains(activeScope))) {
           scope = selectedScope;
         }
       }

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -1091,6 +1091,8 @@
   "settingsConfig.interfaceBehaviorDesc": "Controls interface presentation, notification sounds, and execution submission mode.",
   "settingsConfig.keepToolCallsCollapsed": "Keep tool calls collapsed",
   "settingsConfig.keepToolCallsCollapsedDesc": "Show only compact headers while tools execute.",
+  "settingsConfig.scopeNativeSelectAll": "Scope native Select All (experimental)",
+  "settingsConfig.scopeNativeSelectAllDesc": "Limit whole-page selections from browser or touch menus to the active message, chat, or file. May also narrow deliberate whole-page selections. Turn off if selection handles or menus misbehave. Keyboard shortcuts are unaffected.",
   "settingsConfig.completionSound": "Completion sound",
   "settingsConfig.completionSoundDesc": "Play a tone when the agent completes a run.",
   "settingsConfig.providerUsage": "Provider usage limits",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -1062,6 +1062,8 @@
   "settingsConfig.interfaceBehaviorDesc": "Controls interface presentation, notification sounds, and execution submission mode.",
   "settingsConfig.keepToolCallsCollapsed": "Keep tool calls collapsed",
   "settingsConfig.keepToolCallsCollapsedDesc": "Show only compact headers while tools execute.",
+  "settingsConfig.scopeNativeSelectAll": "ネイティブの「すべて選択」の範囲を制限（試験的）",
+  "settingsConfig.scopeNativeSelectAllDesc": "ブラウザーやタッチメニューによるページ全体の選択を、操作中のメッセージ、チャット、ファイル内に制限します。意図的なページ全体の選択も制限される場合があります。選択ハンドルやメニューに問題がある場合はオフにしてください。キーボードショートカットには影響しません。",
   "settingsConfig.completionSound": "完了音",
   "settingsConfig.completionSoundDesc": "エージェントの実行完了時に音を鳴らします。",
   "settingsConfig.providerUsage": "プロバイダー使用量の制限",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -1062,6 +1062,8 @@
   "settingsConfig.interfaceBehaviorDesc": "控制界面展示、通知提示音及执行发送模式。",
   "settingsConfig.keepToolCallsCollapsed": "保持工具调用折叠",
   "settingsConfig.keepToolCallsCollapsedDesc": "工具执行时仅显示精简标头。",
+  "settingsConfig.scopeNativeSelectAll": "限制原生“全选”范围（实验性）",
+  "settingsConfig.scopeNativeSelectAllDesc": "将浏览器或触控菜单产生的整页选择限制在当前消息、聊天或文件内。也可能缩小主动选择整页的范围。如果选择手柄或菜单出现异常，请关闭此选项。键盘快捷键不受影响。",
   "settingsConfig.completionSound": "完成提示音",
   "settingsConfig.completionSoundDesc": "智能体完成运行时播放提示音。",
   "settingsConfig.providerUsage": "提供商用量限额",


### PR DESCRIPTION
## Summary
Scope Select All to the content the user is working with, rather than the entire application.

- **Ctrl+A / Cmd+A:** select the current message, loaded chat transcript, or file contents. Cross-message selections expand to the transcript; repeated shortcuts stay within the same scope.
- **Native browser/touch menus:** add an off-by-default **Scope native Select All (experimental)** switch under **Settings → Interface & Behavior**, remembered per browser. It corrects whole-page selections after `selectionchange` without replacing or cancelling native menus.
- The native fallback is independent of keyboard scoping. Turning it off restores native menu behavior while Ctrl+A / Cmd+A remain scoped.
- Preserve editors, embedded viewers, ordinary partial selections, IME composition, and pointer drags. Handle hidden/clipped panels and composed selection ranges across shadow DOM.
- Include collapsed extension previews and expanded message details, excluding toolbar/type labels from selected text. Add searchable settings copy in English, Japanese, and Simplified Chinese.

## Known limitation
Browsers do not expose a reliable native Select All intent event. The opt-in fallback can also narrow a deliberately selected whole-page range. Users can disable it if selection handles or menus behave unexpectedly. This remains experimental rather than a claim of universal browser compatibility.

## Verification
- **Requester tested the deployed change and confirmed: “It worked perfectly.”** Browser/device details were not specified; this is user acceptance evidence, not an exhaustive mobile compatibility matrix.
- Linux and Windows CI plus PR quality gates are green for `66c07ff`.
- Typecheck/lint and the 27 focused MessageView tests passed after the final review correction.
- The clean downstream integration build and 680 integration tests passed, with one existing platform skip.
- Real-app Chromium checks covered native editing commands (not just keyboard shortcuts), default-off behavior, on/off persistence across reloads, settings search, keyboard independence, repeated selection, focus precedence, cross-message/partial selections, file contents, composer preservation, and IME/context-menu guards.
- Packaged and publicly served UI verification passed. Only the frontend was restarted; existing API services and the native OMP binary were preserved.

## Review follow-through
Automated reviews ran on the matching [fork companion PR #19](https://github.com/andrebrait/ompweb/pull/19), using the same feature branch and upstream base.

- CodeRabbit reported no actionable code findings.
- Copilot's confirmed scope, IME, retained-selection, and copied-label findings were reproduced and fixed.
- Its `TreeWalker.lastChild()` concern was not adopted: a native browser probe demonstrated nested text traversal through the filtered logical tree. Evidence and accepted/rejected findings are recorded in the [review follow-through](https://github.com/kahme247/ompweb/pull/86#issuecomment-5647872334).

No new dependencies. The deployed downstream integration snapshot is `91f21118a003`; this PR contains only the selection feature and its review fixes.