### PR TITLE
feat: expand complete tool inputs inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **omp-web** (`@kahme247/ompweb`) are documented in this f
 
 ### Fixes & Improvements
 
+- Expand complete tool inputs inline, including multiline code and edit patches, while keeping command previews compact and output visibility unchanged.
 - Keep composer controls on one line, with equally sized Send, Stop, and Queue buttons and model names truncating before short effort labels.
 - Align the + button and primary action with matching composer insets.
 - Clearly dim Attach files while the agent is running; queued messages remain text-only.

--- a/app/globals.css
+++ b/app/globals.css
@@ -3139,7 +3139,7 @@ html.dark .dropdown-surface :is(select, option) {
 }
 .tool-call-command {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 7px;
   min-width: 0;
   padding: 5px 8px;
@@ -3154,11 +3154,50 @@ html.dark .dropdown-surface :is(select, option) {
   flex: 0 0 auto;
 }
 .tool-call-command code {
+  flex: 1;
   min-width: 0;
   overflow: hidden;
   color: var(--text);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.tool-call-input-toggle {
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 4px;
+  border-radius: var(--radius-control);
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+}
+.tool-call-input-toggle:hover {
+  background: var(--bg-hover);
+}
+.tool-call-input-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.tool-call-input {
+  padding: 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+.tool-call-input dl, .tool-call-input dd, .tool-call-input pre {
+  margin: 0;
+}
+.tool-call-input dl > div + div {
+  margin-top: 8px;
+}
+.tool-call-input dt {
+  color: var(--text-muted);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.tool-call-input pre {
+  color: var(--text);
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 .tool-call-output {
   max-height: 260px;

--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import React from "react";
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createJiti } from "jiti";
 
@@ -10,6 +11,57 @@ const jiti = createJiti(import.meta.url, {
 });
 const { MessageView, SafeMarkdownBody, TaskResultPanel, isInterruptedMessage } = await jiti.import("./MessageView.tsx");
 const { CodeBlock } = await jiti.import("./MermaidBlock.tsx");
+const { Collapsible } = await jiti.import("./ui/primitives.tsx");
+
+test("expanded grouped tool inputs follow streaming arguments without toggling output", async () => {
+  const previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  const code = "print('first')\nprint('complete')";
+  const editInput = { path: "/tmp/example.ts", patch: "-old\n+new", options: { dryRun: false } };
+  const toolResults = new Map([["edit-call", {
+    role: "toolResult", toolCallId: "edit-call", content: [{ type: "text", text: "Edit complete" }],
+  }]]);
+  const props = (input) => ({
+    isStreaming: true,
+    toolCallsDefaultCollapsed: false,
+    toolResults,
+    message: {
+      role: "assistant", model: "test", provider: "test",
+      content: [
+        { type: "toolCall", toolCallId: "eval-call", toolName: "eval", input: { language: "py", code: input } },
+        { type: "toolCall", toolCallId: "edit-call", toolName: "edit", input: editInput },
+      ],
+    },
+  });
+  let renderer;
+  try {
+    await act(() => { renderer = TestRenderer.create(React.createElement(MessageView, props("print('first')"))); });
+    // Open both tool rows through the shared disclosure's public change handler.
+    await act(() => {
+      for (const row of renderer.root.findAllByType(Collapsible).slice(1)) row.props.onOpenChange(true);
+    });
+    const toggles = () => renderer.root.findAllByType("button").filter((node) => node.props["aria-controls"] && node.children.includes("Show full input"));
+    const inputPanels = () => renderer.root.findAll((node) => node.type === "div" && node.props.className === "tool-call-input");
+    assert.equal(toggles().length, 2);
+    assert.ok(inputPanels().every((node) => node.props.hidden));
+    await act(() => { for (const toggle of toggles()) toggle.props.onClick(); });
+    assert.equal(inputPanels()[0].findAllByType("pre")[1].children.join(""), "print('first')");
+    assert.equal(inputPanels()[1].findAllByType("pre")[1].children.join(""), editInput.patch);
+    assert.deepEqual(JSON.parse(inputPanels()[1].findAllByType("pre")[2].children.join("")), editInput.options);
+    await act(() => renderer.update(React.createElement(MessageView, props(code))));
+    assert.equal(inputPanels()[0].findAllByType("pre")[1].children.join(""), code);
+    const output = () => renderer.root.findAll((node) => node.type === "pre" && node.props["data-tool-output"] === "true").map((node) => node.children.join(""));
+    assert.deepEqual(output(), ["Edit complete"]);
+    await act(() => {
+      for (const toggle of renderer.root.findAllByType("button").filter((node) => node.children.includes("Collapse input"))) toggle.props.onClick();
+    });
+    assert.ok(inputPanels().every((node) => node.props.hidden));
+    assert.deepEqual(output(), ["Edit complete"]);
+  } finally {
+    await act(() => renderer?.unmount());
+    globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});
 
 test("large message content avoids the markdown pipeline until requested", () => {
   const largeMessage = "x".repeat(100_001);

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useRef, useEffect, useMemo, useCallback, type ComponentProps } from "react";
+import { memo, useState, useId, useRef, useEffect, useMemo, useCallback, type ComponentProps } from "react";
 import { Copy, Check, GitFork, CornerUpLeft, ChevronRight, ChevronDown, Brain, EyeOff, CircleAlert, CircleSlash, LoaderCircle, FileText, Search, FileEdit, Terminal, CheckSquare, Bot, Code2, Globe, MessagesSquare, Wrench } from "lucide-react";
 import { MarkdownBody } from "./MarkdownBody";
 import { ClickableImage } from "./ImageLightbox";
@@ -892,6 +892,8 @@ const ToolCallBlock = memo(function ToolCallBlock({
   // A running tool opens its row when the interface keeps tool calls expanded
   // ("Keep tool calls collapsed" off) so its output is watchable live.
   const [expanded, setExpanded] = useState(Boolean(isStreaming || isRunning) && !defaultCollapsed);
+  const [inputExpanded, setInputExpanded] = useState(false);
+  const inputId = useId();
   // The row can also mount while the tool is idle and start running later (the
   // assistant message commits before `tool_execution_start`). It is never
   // auto-collapsed: the output stays where the user was reading it.
@@ -1009,6 +1011,29 @@ const ToolCallBlock = memo(function ToolCallBlock({
             <div className="tool-call-command">
               <span className="tool-call-command-prompt" aria-hidden>$</span>
               <code>{command}</code>
+              <button
+                type="button"
+                className="tool-call-input-toggle"
+                aria-expanded={inputExpanded}
+                aria-controls={inputId}
+                onClick={() => setInputExpanded((value) => !value)}
+              >
+                {t(inputExpanded ? "messageView.collapseInput" : "messageView.showFullInput")}
+              </button>
+            </div>
+            <div id={inputId} hidden={!inputExpanded} className="tool-call-input">
+              {inputExpanded && (
+                block.input && typeof block.input === "object" && !Array.isArray(block.input) && Object.keys(block.input).length > 0 ? (
+                  <dl>
+                    {Object.entries(block.input).map(([key, value]) => (
+                      <div key={key}>
+                        <dt>{key}</dt>
+                        <dd><pre>{typeof value === "string" ? value : safeJson(value)}</pre></dd>
+                      </div>
+                    ))}
+                  </dl>
+                ) : <pre>{safeJson(block.input)}</pre>
+              )}
             </div>
             {todoSummary && (
               <div className="tool-call-todo-badge">

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1193,7 +1193,11 @@ const ToolCallGroupBlock = memo(function ToolCallGroupBlock({
   );
 }, (prev, next) => (
   prev.items.length === next.items.length
-  && prev.items.every((item, i) => item.block.toolCallId === next.items[i]?.block.toolCallId)
+  && prev.items.every((item, i) => (
+    item.block.toolCallId === next.items[i]?.block.toolCallId
+    && item.block.toolName === next.items[i]?.block.toolName
+    && inputsShallowEqual(item.block.input, next.items[i]?.block.input)
+  ))
   && prev.onOpenFile === next.onOpenFile
   && (!prev.toolResults || !next.toolResults || prev.items.every((item) => prev.toolResults?.get(item.block.toolCallId) === next.toolResults?.get(item.block.toolCallId)))
 ));

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -701,6 +701,8 @@
   "messageView.readFiles": "Read files",
   "messageView.responseError": "Response error",
   "messageView.showDetails": "Show details",
+  "messageView.showFullInput": "Show full input",
+  "messageView.collapseInput": "Collapse input",
   "messageView.showExtensionMessage": "Show extension message",
   "messageView.taskSubagents": "Subagents",
   "messageView.thinking": "Thinking",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -674,6 +674,8 @@
   "messageView.readFiles": "読み取ったファイル",
   "messageView.responseError": "応答エラー",
   "messageView.showDetails": "詳細を表示",
+  "messageView.showFullInput": "入力全体を表示",
+  "messageView.collapseInput": "入力を折りたたむ",
   "messageView.showExtensionMessage": "拡張機能メッセージを表示",
   "messageView.taskSubagents": "サブエージェント",
   "messageView.thinking": "思考",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -674,6 +674,8 @@
   "messageView.readFiles": "已读取的文件",
   "messageView.responseError": "响应错误",
   "messageView.showDetails": "显示详情",
+  "messageView.showFullInput": "显示完整输入",
+  "messageView.collapseInput": "收起输入",
   "messageView.showExtensionMessage": "显示扩展消息",
   "messageView.taskSubagents": "子代理",
   "messageView.thinking": "思考",


### PR DESCRIPTION
## Summary
- Keep compact command previews by default and add an independent Show full input / Collapse input button.
- Display every input argument, including multiline eval code, edit patches, and nested hub arguments, as selectable wrapped text.
- Preserve existing output visibility and tool-row/group behavior; localize controls in English, Japanese, and Simplified Chinese.

Expanded inputs intentionally use normal transcript scrolling rather than a nested fixed-height scroller, so long code and patches remain easy to read and select. Output-collapse defaults are explicitly out of scope.

## Verification
- Typecheck and lint passed.
- Existing test suite: 688 passed, 1 skipped, 0 failures.
- Real Chromium, actual MessageView component in a temporary Next.js fixture: hub/eval/edit/bash at 320, 768, 1024, and 1440px; complete input, unchanged output, no horizontal clipping, Enter/Space expansion and collapse.
- Pointer activation and mobile screenshots verified; fixture removed.
- Condensed adversarial review: no blocking findings.

No production deployment is included.