### PR TITLE
fix(mobile): cap viewport maximum-scale to stop iOS focus zoom

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,6 +62,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  maximumScale: 1,
   viewportFit: "cover",
   interactiveWidget: "resizes-content",
 };


### PR DESCRIPTION
Andre was right about the sub 16px forcing zoom on iOS. Setting font size to 16px within the ompweb settings fixed the issue.


After investigating, I found the composer was missing a viewport cap; that's why small input text triggered auto-zoom on focus. I've tried a one-line fix locally and the zoom issue disappeared for both Chrome and Safari on iOS.

<details>
<summary>click: Before and after videoshots </summary>


https://github.com/user-attachments/assets/7ca57022-db4d-472c-be5d-d9b811ce9cbf

https://github.com/user-attachments/assets/1beb9875-e021-4888-98c6-3258568c2617
</details>

Supersedes #90 (closed accidentally when adding comment with videos).

Closes #83.